### PR TITLE
Improve Laplacian tests for point gravity and kernels

### DIFF
--- a/choclo/tests/test_point_gravity.py
+++ b/choclo/tests/test_point_gravity.py
@@ -749,9 +749,11 @@ class TestLaplacian:
         )
         # Set an atol to avoid getting failures when comparing values close to
         # zero
+        atol = 1e-21
+        rtol = 1e-7
         if first_component == "g_ee":
-            npt.assert_allclose(-g_ee, g_nn + g_uu, rtol=1e-7, atol=1e-21)
+            npt.assert_allclose(-g_ee, g_nn + g_uu, rtol=rtol, atol=atol)
         if first_component == "g_nn":
-            npt.assert_allclose(-g_nn, g_ee + g_uu, rtol=1e-7, atol=1e-21)
+            npt.assert_allclose(-g_nn, g_ee + g_uu, rtol=rtol, atol=atol)
         if first_component == "g_uu":
-            npt.assert_allclose(-g_uu, g_ee + g_nn, rtol=1e-7, atol=1e-21)
+            npt.assert_allclose(-g_uu, g_ee + g_nn, rtol=rtol, atol=atol)


### PR DESCRIPTION
Test the Laplacian kernels and gravity forward functions for point sources on
a whole set of observation points. Perform the test three different times,
choosing each one of the diagonal tensor components as the one in the left side
of the equation.