### PR TITLE
Import dipole in __init__.py to make the module available

### DIFF
--- a/choclo/__init__.py
+++ b/choclo/__init__.py
@@ -5,5 +5,5 @@
 # This code is part of the Fatiando a Terra project (https://www.fatiando.org)
 #
 # Import functions/classes to make the public API
-from . import point, prism, dipole
+from . import dipole, point, prism
 from ._version import __version__

--- a/choclo/__init__.py
+++ b/choclo/__init__.py
@@ -5,5 +5,5 @@
 # This code is part of the Fatiando a Terra project (https://www.fatiando.org)
 #
 # Import functions/classes to make the public API
-from . import point, prism
+from . import point, prism, dipole
 from ._version import __version__


### PR DESCRIPTION
Import `dipole` submodule in `choclo/__init__.py` to make it available when
importing `choclo` as a whole.
