### PR TITLE
Speed-up the dipole magnetic field by ~25x

### DIFF
--- a/choclo/dipole/_forward.py
+++ b/choclo/dipole/_forward.py
@@ -84,21 +84,24 @@ def magnetic_field(
     :math:`\lVert \cdot \rVert` refer to the :math:`L_2` norm
     and :math:`\mu_0` is the vacuum magnetic permeability.
     """
-    r_vector = np.array(
-        (
-            easting_p - easting_q,
-            northing_p - northing_q,
-            upward_p - upward_q,
-        )
-    )
-    distance = np.sqrt(np.sum(r_vector**2))
+    r_e = easting_p - easting_q
+    r_n = northing_p - northing_q
+    r_u = upward_p - upward_q
+    distance = np.sqrt(r_e**2 + r_n**2 + r_u**2)
     dotproduct = (
-        magnetic_moment[0] * r_vector[0]
-        + magnetic_moment[1] * r_vector[1]
-        + magnetic_moment[2] * r_vector[2]
+        magnetic_moment[0] * r_e + magnetic_moment[1] * r_n + magnetic_moment[2] * r_u
     )
-    result = 3 * dotproduct * r_vector / distance**5 - magnetic_moment / distance**3
-    return VACUUM_MAGNETIC_PERMEABILITY / 4 / np.pi * result
+    c_m = VACUUM_MAGNETIC_PERMEABILITY / 4 / np.pi
+    b_e = c_m * (
+        3 * dotproduct * r_e / distance**5 - magnetic_moment[0] / distance**3
+    )
+    b_n = c_m * (
+        3 * dotproduct * r_n / distance**5 - magnetic_moment[1] / distance**3
+    )
+    b_u = c_m * (
+        3 * dotproduct * r_u / distance**5 - magnetic_moment[2] / distance**3
+    )
+    return b_e, b_n, b_u
 
 
 @jit(nopython=True)
@@ -166,23 +169,14 @@ def magnetic_e(
     :math:`\lVert \cdot \rVert` refer to the :math:`L_2` norm
     and :math:`\mu_0` is the vacuum magnetic permeability.
     """
-    r_vector = np.array(
-        (
-            easting_p - easting_q,
-            northing_p - northing_q,
-            upward_p - upward_q,
-        )
-    )
-    distance = np.sqrt(np.sum(r_vector**2))
+    r_e = easting_p - easting_q
+    r_n = northing_p - northing_q
+    r_u = upward_p - upward_q
+    distance = np.sqrt(r_e**2 + r_n**2 + r_u**2)
     dotproduct = (
-        magnetic_moment[0] * r_vector[0]
-        + magnetic_moment[1] * r_vector[1]
-        + magnetic_moment[2] * r_vector[2]
+        magnetic_moment[0] * r_e + magnetic_moment[1] * r_n + magnetic_moment[2] * r_u
     )
-    result = (
-        3 * dotproduct * r_vector[0] / distance**5
-        - magnetic_moment[0] / distance**3
-    )
+    result = 3 * dotproduct * r_e / distance**5 - magnetic_moment[0] / distance**3
     return VACUUM_MAGNETIC_PERMEABILITY / 4 / np.pi * result
 
 
@@ -251,23 +245,14 @@ def magnetic_n(
     :math:`\lVert \cdot \rVert` refer to the :math:`L_2` norm
     and :math:`\mu_0` is the vacuum magnetic permeability.
     """
-    r_vector = np.array(
-        (
-            easting_p - easting_q,
-            northing_p - northing_q,
-            upward_p - upward_q,
-        )
-    )
-    distance = np.sqrt(np.sum(r_vector**2))
+    r_e = easting_p - easting_q
+    r_n = northing_p - northing_q
+    r_u = upward_p - upward_q
+    distance = np.sqrt(r_e**2 + r_n**2 + r_u**2)
     dotproduct = (
-        magnetic_moment[0] * r_vector[0]
-        + magnetic_moment[1] * r_vector[1]
-        + magnetic_moment[2] * r_vector[2]
+        magnetic_moment[0] * r_e + magnetic_moment[1] * r_n + magnetic_moment[2] * r_u
     )
-    result = (
-        3 * dotproduct * r_vector[1] / distance**5
-        - magnetic_moment[1] / distance**3
-    )
+    result = 3 * dotproduct * r_n / distance**5 - magnetic_moment[1] / distance**3
     return VACUUM_MAGNETIC_PERMEABILITY / 4 / np.pi * result
 
 
@@ -336,21 +321,12 @@ def magnetic_u(
     :math:`\lVert \cdot \rVert` refer to the :math:`L_2` norm
     and :math:`\mu_0` is the vacuum magnetic permeability.
     """
-    r_vector = np.array(
-        (
-            easting_p - easting_q,
-            northing_p - northing_q,
-            upward_p - upward_q,
-        )
-    )
-    distance = np.sqrt(np.sum(r_vector**2))
+    r_e = easting_p - easting_q
+    r_n = northing_p - northing_q
+    r_u = upward_p - upward_q
+    distance = np.sqrt(r_e**2 + r_n**2 + r_u**2)
     dotproduct = (
-        magnetic_moment[0] * r_vector[0]
-        + magnetic_moment[1] * r_vector[1]
-        + magnetic_moment[2] * r_vector[2]
+        magnetic_moment[0] * r_e + magnetic_moment[1] * r_n + magnetic_moment[2] * r_u
     )
-    result = (
-        3 * dotproduct * r_vector[2] / distance**5
-        - magnetic_moment[2] / distance**3
-    )
+    result = 3 * dotproduct * r_u / distance**5 - magnetic_moment[2] / distance**3
     return VACUUM_MAGNETIC_PERMEABILITY / 4 / np.pi * result


### PR DESCRIPTION
Remove the numpy array creation from the dipole magnetic field calculations to achieve a speed-up of approximated 25x. Array creation happened when making the r (distance) vector and in the multiple component case when producing the final field with numpy-based calculations. Replace by using 3 variables and explicitly calculating each component separately.

Running this benchmark script:

```python
# Copyright (c) 2022 The Choclo Developers.
# Distributed under the terms of the BSD 3-Clause License.
# SPDX-License-Identifier: BSD-3-Clause
#
# This code is part of the Fatiando a Terra project (https://www.fatiando.org)
#
import choclo
import numpy as np
import time
import numba


@numba.jit
def calc(dummy, moment):
    for i in range(dummy.size):
        dummy[i] += choclo.dipole.magnetic_e(
            dummy[i], dummy[i], dummy[i],
            1, 1, -1, moment,
        )
    return dummy


@numba.jit
def calc_full(dummy, moment):
    for i in range(dummy.size):
        be, bn, bu = choclo.dipole.magnetic_field(
            dummy[i], dummy[i], dummy[i],
            1, 1, -1, moment,
        )
        dummy[i] += be
        dummy[i] += bn
        dummy[i] += bu
    return dummy


def timeit(func, *args):
    times = []
    for _ in range(20):
        start = time.time_ns()
        func(*args)
        duration = (time.time_ns() - start) * 1e-9
        times.append(duration)
    print(f"mean: {np.mean(times):.6f} s")
    print(f" std: {np.std(times):.6f} s")


dummy = np.linspace(0, 1, 1000000)
moment = np.array([1, 1, 1])

# Jit compile first
calc(dummy, moment)
calc_full(dummy, moment)

print("Single component:")
timeit(calc, dummy, moment)
print("\nFull vector:")
timeit(calc, dummy, moment)
```

produced:

```
main branch
-----------
Single component:
mean: 0.137531 s
 std: 0.002517 s

Full vector:
mean: 0.140477 s
 std: 0.002112 s

this PR
-------
Single component:
mean: 0.005826 s
 std: 0.000318 s

Full vector:
mean: 0.006058 s
 std: 0.000411 s
```

<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
