### PR TITLE
Add GitHub Action to publish Choclo in PyPI

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,126 @@
+# Publish archives to PyPI and TestPyPI using GitHub Actions.
+#
+# NOTE: Pin actions to a specific commit to avoid having the authentication
+# token stolen if the Action is compromised. See the comments and links here:
+# https://github.com/pypa/gh-action-pypi-publish/issues/27
+#
+name: pypi
+
+# Runs on these events but only publish on pushes to main (to test pypi) and
+# releases
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
+
+# Use bash by default in all jobs
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  #############################################################################
+  # Build and check source and wheel distributions
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          # Need to fetch more than the last commit so that setuptools_scm can
+          # create the correct version string. If the number of commits since
+          # the last release is greater than this, the version will still be
+          # wrong. Increase if necessary.
+          fetch-depth: 100
+          # The GitHub token is preserved by default but this job doesn't need
+          # to be able to push to GitHub.
+          persist-credentials: false
+
+      # Need the tags so that setuptools-scm can form a valid version number
+      - name: Fetch git tags
+        run: git fetch origin 'refs/tags/*:refs/tags/*'
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+
+      - name: Install requirements
+        run: python -m pip install -r env/requirements-build.txt
+
+      - name: List installed packages
+        run: python -m pip freeze
+
+      - name: Don't use local version numbers for TestPyPI uploads
+        if: github.event_name != 'release'
+        run: |
+          # Change setuptools-scm local_scheme to "no-local-version" so the
+          # local part of the version isn't included, making the version string
+          # compatible with Test PyPI.
+          sed --in-place "s/node-and-date/no-local-version/g" pyproject.toml
+
+      - name: Build source and wheel distributions
+        run: |
+          python setup.py sdist bdist_wheel
+          echo ""
+          echo "Generated files:"
+          ls -lh dist/
+
+      - name: Check the archives
+        run: twine check dist/*
+
+      # Store the archives as a build artifact so we can deploy them later
+      - name: Upload archives as artifacts
+        # Only if not a pull request
+        if: success() && github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v2
+        with:
+          name: pypi-${{ github.sha }}
+          path: dist
+
+  #############################################################################
+  # Publish built wheels and source archives to PyPI and test PyPI
+  publish:
+    runs-on: ubuntu-latest
+    # Only publish from the origin repository, not forks
+    if: github.repository_owner == 'fatiando' && github.event_name != 'pull_request'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          # The GitHub token is preserved by default but this job doesn't need
+          # to be able to push to GitHub.
+          persist-credentials: false
+
+      - name: Download built source and wheel packages
+        uses: actions/download-artifact@v2
+        with:
+          name: pypi-${{ github.sha }}
+          path: dist
+
+      - name: Publish to Test PyPI
+        # Only publish to TestPyPI when a PR is merged (pushed to main)
+        if: success() && github.event_name == 'push'
+        uses: pypa/gh-action-pypi-publish@bce3b74dbf8cc32833ffba9d15f83425c1a736e0
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_TOKEN}}
+          repository_url: https://test.pypi.org/legacy/
+          # Allow existing releases on test PyPI without errors.
+          # NOT TO BE USED in PyPI!
+          skip_existing: true
+
+      - name: Publish to PyPI
+        # Only publish to PyPI when a release triggers the build
+        if: success() && github.event_name == 'release'
+        uses: pypa/gh-action-pypi-publish@bce3b74dbf8cc32833ffba9d15f83425c1a736e0
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN}}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -6,8 +6,7 @@
 #
 name: pypi
 
-# Runs on these events but only publish on pushes to main (to test pypi) and
-# releases
+# Only run for pushes to the main branch and releases.
 on:
   pull_request:
   push:
@@ -23,8 +22,7 @@ defaults:
     shell: bash
 
 jobs:
-  #############################################################################
-  # Build and check source and wheel distributions
+
   build:
     runs-on: ubuntu-latest
 
@@ -57,17 +55,9 @@ jobs:
       - name: List installed packages
         run: python -m pip freeze
 
-      - name: Don't use local version numbers for TestPyPI uploads
-        if: github.event_name != 'release'
-        run: |
-          # Change setuptools-scm local_scheme to "no-local-version" so the
-          # local part of the version isn't included, making the version string
-          # compatible with Test PyPI.
-          sed --in-place "s/node-and-date/no-local-version/g" pyproject.toml
-
       - name: Build source and wheel distributions
         run: |
-          python setup.py sdist bdist_wheel
+          make build
           echo ""
           echo "Generated files:"
           ls -lh dist/
@@ -84,10 +74,9 @@ jobs:
           name: pypi-${{ github.sha }}
           path: dist
 
-  #############################################################################
-  # Publish built wheels and source archives to PyPI and test PyPI
   publish:
     runs-on: ubuntu-latest
+    needs: build
     # Only publish from the origin repository, not forks
     if: github.repository_owner == 'fatiando' && github.event_name != 'pull_request'
 
@@ -99,7 +88,8 @@ jobs:
           # to be able to push to GitHub.
           persist-credentials: false
 
-      - name: Download built source and wheel packages
+      # Fetch the built archives from the "build" job
+      - name: Download built archives artifact
         uses: actions/download-artifact@v2
         with:
           name: pypi-${{ github.sha }}
@@ -111,7 +101,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@bce3b74dbf8cc32833ffba9d15f83425c1a736e0
         with:
           user: __token__
-          password: ${{ secrets.TEST_PYPI_TOKEN}}
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
           # Allow existing releases on test PyPI without errors.
           # NOT TO BE USED in PyPI!
@@ -123,4 +113,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@bce3b74dbf8cc32833ffba9d15f83425c1a736e0
         with:
           user: __token__
-          password: ${{ secrets.PYPI_TOKEN}}
+          password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Add a new `pypi.yml` GitHub Actions workflow to upload and publish Choclo releases to PyPI.