### PR TITLE
Fix bug on non-diagonal tensor components of prisms

### DIFF
--- a/choclo/prism/_gravity.py
+++ b/choclo/prism/_gravity.py
@@ -76,9 +76,9 @@ def gravity_pot(easting, northing, upward, prism, density):
     .. math::
 
         k_V(x, y, z) &=
-            x y \, \text{ln2} (z, r)
-            + y z \, \text{ln2} (x, r)
-            + z x \, \text{ln2} (y, r) \\
+            x y \, \operatorname{safe-ln} (z, r)
+            + y z \, \operatorname{safe-ln} (x, r)
+            + z x \, \operatorname{safe-ln} (y, r) \\
             - \frac{x^2}{2} &\text{arctan2} \left( \frac{yz}{xr} \right)
             - \frac{y^2}{2} \text{arctan2} \left( \frac{zx}{yr} \right)
             - \frac{z^2}{2} \text{arctan2} \left( \frac{xy}{zr} \right),
@@ -101,12 +101,12 @@ def gravity_pot(easting, northing, upward, prism, density):
     are the shifted coordinates of the prism boundaries and :math:`G` is the
     Universal Gravitational Constant.
 
-    The :math:`\text{ln2}` and :math:`\text{arctan2}` functions are defined as
-    follows:
+    The :math:`\operatorname{safe-ln}` and :math:`\text{arctan2}` functions are
+    defined as follows:
 
     .. math::
 
-        \text{ln2}(x, r) =
+        \operatorname{safe-ln}(x, r) =
         \begin{cases}
             0 & x = 0, r = 0 \\
             \ln(x + r) & x \ge 0 \\
@@ -194,8 +194,8 @@ def gravity_e(easting, northing, upward, prism, density):
 
         k_x(x, y, z) =
             \left[
-            y \, \text{ln2} (z, r)
-            + z \, \text{ln2} (y, r)
+            y \, \operatorname{safe-ln} (z, r)
+            + z \, \operatorname{safe-ln} (y, r)
             - x \, \text{arctan2} \left( \frac{yz}{xr} \right)
             \right]
 
@@ -217,12 +217,12 @@ def gravity_e(easting, northing, upward, prism, density):
     are the shifted coordinates of the prism boundaries and :math:`G` is the
     Universal Gravitational Constant.
 
-    The :math:`\text{ln2}` and :math:`\text{arctan2}` functions are defined as
-    follows:
+    The :math:`\operatorname{safe-ln}` and :math:`\text{arctan2}` functions are
+    defined as follows:
 
     .. math::
 
-        \text{ln2}(x, r) =
+        \operatorname{safe-ln}(x, r) =
         \begin{cases}
             0 & x = 0, r = 0 \\
             \ln(x + r) & x \ge 0 \\
@@ -310,8 +310,8 @@ def gravity_n(easting, northing, upward, prism, density):
 
         k_y(x, y, z) =
             \left[
-            z \, \text{ln2} (x, r)
-            + x \, \text{ln2} (z, r)
+            z \, \operatorname{safe-ln} (x, r)
+            + x \, \operatorname{safe-ln} (z, r)
             - y \, \text{arctan2} \left( \frac{zx}{yr} \right)
             \right]
 
@@ -333,12 +333,12 @@ def gravity_n(easting, northing, upward, prism, density):
     are the shifted coordinates of the prism boundaries and :math:`G` is the
     Universal Gravitational Constant.
 
-    The :math:`\text{ln2}` and :math:`\text{arctan2}` functions are defined as
-    follows:
+    The :math:`\operatorname{safe-ln}` and :math:`\text{arctan2}` functions are
+    defined as follows:
 
     .. math::
 
-        \text{ln2}(x, r) =
+        \operatorname{safe-ln}(x, r) =
         \begin{cases}
             0 & x = 0, r = 0 \\
             \ln(x + r) & x \ge 0 \\
@@ -426,8 +426,8 @@ def gravity_u(easting, northing, upward, prism, density):
 
         k_z(x, y, z) =
             - \left[
-            x \, \text{ln2} (y, r)
-            + y \, \text{ln2} (x, r)
+            x \, \operatorname{safe-ln} (y, r)
+            + y \, \operatorname{safe-ln} (x, r)
             - z \, \text{arctan2} \left( \frac{xy}{zr} \right)
             \right]
 
@@ -455,12 +455,12 @@ def gravity_u(easting, northing, upward, prism, density):
         the **upward** component of the acceleration. [Nagy2000]_ and
         [Nagy2002]_ equation corresponds to the *downward* coordinate.
 
-    The :math:`\text{ln2}` and :math:`\text{arctan2}` functions are defined as
-    follows:
+    The :math:`\operatorname{safe-ln}` and :math:`\text{arctan2}` functions are
+    defined as follows:
 
     .. math::
 
-        \text{ln2}(x, r) =
+        \operatorname{safe-ln}(x, r) =
         \begin{cases}
             0 & x = 0, r = 0 \\
             \ln(x + r) & x \ge 0 \\
@@ -846,7 +846,7 @@ def gravity_en(easting, northing, upward, prism, density):
 
     .. math::
 
-        k_{xy}(x, y, z) = \text{ln2} \left( z, r \right),
+        k_{xy}(x, y, z) = \operatorname{safe-ln} \left( z, r \right),
 
     .. math::
 
@@ -866,11 +866,11 @@ def gravity_en(easting, northing, upward, prism, density):
     are the shifted coordinates of the prism boundaries and :math:`G` is the
     Universal Gravitational Constant.
 
-    The :math:`\text{ln2}` function is defined as follows:
+    The :math:`\operatorname{safe-ln}` function is defined as follows:
 
     .. math::
 
-        \text{ln2}(x, r) =
+        \operatorname{safe-ln}(x, r) =
         \begin{cases}
             0 & x = 0, r = 0 \\
             \ln(x + r) & x \ge 0 \\
@@ -946,7 +946,7 @@ def gravity_eu(easting, northing, upward, prism, density):
 
     .. math::
 
-        k_{xz}(x, y, z) = \text{ln2} \left( y, r \right),
+        k_{xz}(x, y, z) = \operatorname{safe-ln} \left( y, r \right),
 
     .. math::
 
@@ -966,11 +966,11 @@ def gravity_eu(easting, northing, upward, prism, density):
     are the shifted coordinates of the prism boundaries and :math:`G` is the
     Universal Gravitational Constant.
 
-    The :math:`\text{ln2}` function is defined as follows:
+    The :math:`\operatorname{safe-ln}` function is defined as follows:
 
     .. math::
 
-        \text{ln2}(x, r) =
+        \operatorname{safe-ln}(x, r) =
         \begin{cases}
             0 & x = 0, r = 0 \\
             \ln(x + r) & x \ge 0 \\
@@ -1046,7 +1046,7 @@ def gravity_nu(easting, northing, upward, prism, density):
 
     .. math::
 
-        k_{yz}(x, y, z) = \text{ln2} \left( x, r \right),
+        k_{yz}(x, y, z) = \operatorname{safe-ln} \left( x, r \right),
 
     .. math::
 
@@ -1066,11 +1066,11 @@ def gravity_nu(easting, northing, upward, prism, density):
     are the shifted coordinates of the prism boundaries and :math:`G` is the
     Universal Gravitational Constant.
 
-    The :math:`\text{ln2}` function is defined as follows:
+    The :math:`\operatorname{safe-ln}` function is defined as follows:
 
     .. math::
 
-        \text{ln2}(x, r) =
+        \operatorname{safe-ln}(x, r) =
         \begin{cases}
             0 & x = 0, r = 0 \\
             \ln(x + r) & x \ge 0 \\

--- a/choclo/prism/_gravity.py
+++ b/choclo/prism/_gravity.py
@@ -546,8 +546,7 @@ def gravity_ee(easting, northing, upward, prism, density):
 
     .. math::
 
-        k_{xx}(x, y, z) =
-            - \operatorname{safe-arctan} \left( yz, xr \right),
+        k_{xx}(x, y, z) = - \operatorname{safe-arctan} \left( yz, xr \right),
 
     .. math::
 
@@ -647,8 +646,7 @@ def gravity_nn(easting, northing, upward, prism, density):
 
     .. math::
 
-        k_{yy}(x, y, z) =
-            - \operatorname{safe-arctan} \left( zx, yr \right),
+        k_{yy}(x, y, z) = - \operatorname{safe-arctan} \left( zx, yr \right),
 
     .. math::
 
@@ -748,8 +746,7 @@ def gravity_uu(easting, northing, upward, prism, density):
 
     .. math::
 
-        k_{zz}(x, y, z) =
-            - \operatorname{safe-arctan} \left( xy, zr \right),
+        k_{zz}(x, y, z) = - \operatorname{safe-arctan} \left( xy, zr \right),
 
     .. math::
 

--- a/choclo/prism/_gravity.py
+++ b/choclo/prism/_gravity.py
@@ -106,10 +106,12 @@ def gravity_pot(easting, northing, upward, prism, density):
 
     .. math::
 
-        \text{ln2}(x) =
+        \text{ln2}(x, r) =
         \begin{cases}
-            0 & |x| < 10^{-10} \\
-            \ln (x)
+            0 & x = 0, r = 0 \\
+            \ln(x + r) & x \ge 0 \\
+            \ln((r^2 - x^2) / (r - x)) & x < 0, r \ne -x \\
+            -\ln(-2 x) & x < 0, r = -x
         \end{cases}
 
     .. math::
@@ -220,10 +222,12 @@ def gravity_e(easting, northing, upward, prism, density):
 
     .. math::
 
-        \text{ln2}(x) =
+        \text{ln2}(x, r) =
         \begin{cases}
-            0 & |x| < 10^{-10} \\
-            \ln (x)
+            0 & x = 0, r = 0 \\
+            \ln(x + r) & x \ge 0 \\
+            \ln((r^2 - x^2) / (r - x)) & x < 0, r \ne -x \\
+            -\ln(-2 x) & x < 0, r = -x
         \end{cases}
 
     .. math::
@@ -334,10 +338,12 @@ def gravity_n(easting, northing, upward, prism, density):
 
     .. math::
 
-        \text{ln2}(x) =
+        \text{ln2}(x, r) =
         \begin{cases}
-            0 & |x| < 10^{-10} \\
-            \ln (x)
+            0 & x = 0, r = 0 \\
+            \ln(x + r) & x \ge 0 \\
+            \ln((r^2 - x^2) / (r - x)) & x < 0, r \ne -x \\
+            -\ln(-2 x) & x < 0, r = -x
         \end{cases}
 
     .. math::
@@ -454,10 +460,12 @@ def gravity_u(easting, northing, upward, prism, density):
 
     .. math::
 
-        \text{ln2}(x) =
+        \text{ln2}(x, r) =
         \begin{cases}
-            0 & |x| < 10^{-10} \\
-            \ln (x)
+            0 & x = 0, r = 0 \\
+            \ln(x + r) & x \ge 0 \\
+            \ln((r^2 - x^2) / (r - x)) & x < 0, r \ne -x \\
+            -\ln(-2 x) & x < 0, r = -x
         \end{cases}
 
     .. math::
@@ -862,10 +870,12 @@ def gravity_en(easting, northing, upward, prism, density):
 
     .. math::
 
-        \text{ln2}(x) =
+        \text{ln2}(x, r) =
         \begin{cases}
-            0 & |x| < 10^{-10} \\
-            \ln (x)
+            0 & x = 0, r = 0 \\
+            \ln(x + r) & x \ge 0 \\
+            \ln((r^2 - x^2) / (r - x)) & x < 0, r \ne -x \\
+            -\ln(-2 x) & x < 0, r = -x
         \end{cases}
 
     It was defined after [Fukushima2020]_ and guarantee a good accuracy on any
@@ -960,10 +970,12 @@ def gravity_eu(easting, northing, upward, prism, density):
 
     .. math::
 
-        \text{ln2}(x) =
+        \text{ln2}(x, r) =
         \begin{cases}
-            0 & |x| < 10^{-10} \\
-            \ln (x)
+            0 & x = 0, r = 0 \\
+            \ln(x + r) & x \ge 0 \\
+            \ln((r^2 - x^2) / (r - x)) & x < 0, r \ne -x \\
+            -\ln(-2 x) & x < 0, r = -x
         \end{cases}
 
     It was defined after [Fukushima2020]_ and guarantee a good accuracy on any
@@ -1058,10 +1070,12 @@ def gravity_nu(easting, northing, upward, prism, density):
 
     .. math::
 
-        \text{ln2}(x) =
+        \text{ln2}(x, r) =
         \begin{cases}
-            0 & |x| < 10^{-10} \\
-            \ln (x)
+            0 & x = 0, r = 0 \\
+            \ln(x + r) & x \ge 0 \\
+            \ln((r^2 - x^2) / (r - x)) & x < 0, r \ne -x \\
+            -\ln(-2 x) & x < 0, r = -x
         \end{cases}
 
     It was defined after [Fukushima2020]_ and guarantee a good accuracy on any

--- a/choclo/prism/_gravity.py
+++ b/choclo/prism/_gravity.py
@@ -76,9 +76,9 @@ def gravity_pot(easting, northing, upward, prism, density):
     .. math::
 
         k_V(x, y, z) &=
-            x y \, \text{ln2} (z + r)
-            + y z \, \text{ln2} (x + r)
-            + z x \, \text{ln2} (y + r) \\
+            x y \, \text{ln2} (z, r)
+            + y z \, \text{ln2} (x, r)
+            + z x \, \text{ln2} (y, r) \\
             - \frac{x^2}{2} &\text{arctan2} \left( \frac{yz}{xr} \right)
             - \frac{y^2}{2} \text{arctan2} \left( \frac{zx}{yr} \right)
             - \frac{z^2}{2} \text{arctan2} \left( \frac{xy}{zr} \right),
@@ -194,8 +194,8 @@ def gravity_e(easting, northing, upward, prism, density):
 
         k_x(x, y, z) =
             \left[
-            y \, \text{ln2} (z + r)
-            + z \, \text{ln2} (y + r)
+            y \, \text{ln2} (z, r)
+            + z \, \text{ln2} (y, r)
             - x \, \text{arctan2} \left( \frac{yz}{xr} \right)
             \right]
 
@@ -310,8 +310,8 @@ def gravity_n(easting, northing, upward, prism, density):
 
         k_y(x, y, z) =
             \left[
-            z \, \text{ln2} (x + r)
-            + x \, \text{ln2} (z + r)
+            z \, \text{ln2} (x, r)
+            + x \, \text{ln2} (z, r)
             - y \, \text{arctan2} \left( \frac{zx}{yr} \right)
             \right]
 
@@ -426,8 +426,8 @@ def gravity_u(easting, northing, upward, prism, density):
 
         k_z(x, y, z) =
             - \left[
-            x \, \text{ln2} (y + r)
-            + y \, \text{ln2} (x + r)
+            x \, \text{ln2} (y, r)
+            + y \, \text{ln2} (x, r)
             - z \, \text{arctan2} \left( \frac{xy}{zr} \right)
             \right]
 
@@ -846,7 +846,7 @@ def gravity_en(easting, northing, upward, prism, density):
 
     .. math::
 
-        k_{xy}(x, y, z) = \text{ln2} \left( z + r \right),
+        k_{xy}(x, y, z) = \text{ln2} \left( z, r \right),
 
     .. math::
 
@@ -946,7 +946,7 @@ def gravity_eu(easting, northing, upward, prism, density):
 
     .. math::
 
-        k_{xz}(x, y, z) = \text{ln2} \left( y + r \right),
+        k_{xz}(x, y, z) = \text{ln2} \left( y, r \right),
 
     .. math::
 
@@ -1046,7 +1046,7 @@ def gravity_nu(easting, northing, upward, prism, density):
 
     .. math::
 
-        k_{yz}(x, y, z) = \text{ln2} \left( x + r \right),
+        k_{yz}(x, y, z) = \text{ln2} \left( x, r \right),
 
     .. math::
 

--- a/choclo/prism/_gravity.py
+++ b/choclo/prism/_gravity.py
@@ -79,9 +79,9 @@ def gravity_pot(easting, northing, upward, prism, density):
             x y \, \operatorname{safe-ln} (z, r)
             + y z \, \operatorname{safe-ln} (x, r)
             + z x \, \operatorname{safe-ln} (y, r) \\
-            - \frac{x^2}{2} &\text{arctan2} \left( \frac{yz}{xr} \right)
-            - \frac{y^2}{2} \text{arctan2} \left( \frac{zx}{yr} \right)
-            - \frac{z^2}{2} \text{arctan2} \left( \frac{xy}{zr} \right),
+            - \frac{x^2}{2} &\operatorname{safe-arctan} \left( yz, xr \right)
+            - \frac{y^2}{2} \operatorname{safe-arctan} \left( zx, yr \right)
+            - \frac{z^2}{2} \operatorname{safe-arctan} \left( xy, zr \right),
 
     .. math::
 
@@ -101,8 +101,8 @@ def gravity_pot(easting, northing, upward, prism, density):
     are the shifted coordinates of the prism boundaries and :math:`G` is the
     Universal Gravitational Constant.
 
-    The :math:`\operatorname{safe-ln}` and :math:`\text{arctan2}` functions are
-    defined as follows:
+    The :math:`\operatorname{safe-ln}` and :math:`\operatorname{safe-arctan}`
+    functions are defined as follows:
 
     .. math::
 
@@ -116,7 +116,7 @@ def gravity_pot(easting, northing, upward, prism, density):
 
     .. math::
 
-        \text{arctan2} \left( \frac{y}{x} \right) =
+        \operatorname{safe-arctan} \left( y, x \right) =
         \begin{cases}
             \text{arctan}\left( \frac{y}{x} \right) & x \ne 0 \\
             \frac{\pi}{2} & x = 0 \quad \text{and} \quad y > 0 \\
@@ -196,7 +196,7 @@ def gravity_e(easting, northing, upward, prism, density):
             \left[
             y \, \operatorname{safe-ln} (z, r)
             + z \, \operatorname{safe-ln} (y, r)
-            - x \, \text{arctan2} \left( \frac{yz}{xr} \right)
+            - x \, \operatorname{safe-arctan} \left( yz, xr \right)
             \right]
 
     .. math::
@@ -217,8 +217,8 @@ def gravity_e(easting, northing, upward, prism, density):
     are the shifted coordinates of the prism boundaries and :math:`G` is the
     Universal Gravitational Constant.
 
-    The :math:`\operatorname{safe-ln}` and :math:`\text{arctan2}` functions are
-    defined as follows:
+    The :math:`\operatorname{safe-ln}` and :math:`\operatorname{safe-arctan}`
+    functions are defined as follows:
 
     .. math::
 
@@ -232,7 +232,7 @@ def gravity_e(easting, northing, upward, prism, density):
 
     .. math::
 
-        \text{arctan2} \left( \frac{y}{x} \right) =
+        \operatorname{safe-arctan} \left( y, x \right) =
         \begin{cases}
             \text{arctan}\left( \frac{y}{x} \right) & x \ne 0 \\
             \frac{\pi}{2} & x = 0 \quad \text{and} \quad y > 0 \\
@@ -312,7 +312,7 @@ def gravity_n(easting, northing, upward, prism, density):
             \left[
             z \, \operatorname{safe-ln} (x, r)
             + x \, \operatorname{safe-ln} (z, r)
-            - y \, \text{arctan2} \left( \frac{zx}{yr} \right)
+            - y \, \operatorname{safe-arctan} \left( zx, yr \right)
             \right]
 
     .. math::
@@ -333,8 +333,8 @@ def gravity_n(easting, northing, upward, prism, density):
     are the shifted coordinates of the prism boundaries and :math:`G` is the
     Universal Gravitational Constant.
 
-    The :math:`\operatorname{safe-ln}` and :math:`\text{arctan2}` functions are
-    defined as follows:
+    The :math:`\operatorname{safe-ln}` and :math:`\operatorname{safe-arctan}`
+    functions are defined as follows:
 
     .. math::
 
@@ -348,7 +348,7 @@ def gravity_n(easting, northing, upward, prism, density):
 
     .. math::
 
-        \text{arctan2} \left( \frac{y}{x} \right) =
+        \operatorname{safe-arctan} \left( y, x \right) =
         \begin{cases}
             \text{arctan}\left( \frac{y}{x} \right) & x \ne 0 \\
             \frac{\pi}{2} & x = 0 \quad \text{and} \quad y > 0 \\
@@ -428,7 +428,7 @@ def gravity_u(easting, northing, upward, prism, density):
             - \left[
             x \, \operatorname{safe-ln} (y, r)
             + y \, \operatorname{safe-ln} (x, r)
-            - z \, \text{arctan2} \left( \frac{xy}{zr} \right)
+            - z \, \operatorname{safe-arctan} \left( xy, zr \right)
             \right]
 
     .. math::
@@ -455,8 +455,8 @@ def gravity_u(easting, northing, upward, prism, density):
         the **upward** component of the acceleration. [Nagy2000]_ and
         [Nagy2002]_ equation corresponds to the *downward* coordinate.
 
-    The :math:`\operatorname{safe-ln}` and :math:`\text{arctan2}` functions are
-    defined as follows:
+    The :math:`\operatorname{safe-ln}` and :math:`\operatorname{safe-arctan}`
+    functions are defined as follows:
 
     .. math::
 
@@ -470,7 +470,7 @@ def gravity_u(easting, northing, upward, prism, density):
 
     .. math::
 
-        \text{arctan2} \left( \frac{y}{x} \right) =
+        \operatorname{safe-arctan} \left( y, x \right) =
         \begin{cases}
             \text{arctan}\left( \frac{y}{x} \right) & x \ne 0 \\
             \frac{\pi}{2} & x = 0 \quad \text{and} \quad y > 0 \\
@@ -546,7 +546,8 @@ def gravity_ee(easting, northing, upward, prism, density):
 
     .. math::
 
-        k_{xx}(x, y, z) = - \text{arctan2} \left( \frac{yz}{xr} \right),
+        k_{xx}(x, y, z) =
+            - \operatorname{safe-arctan} \left( yz, xr \right),
 
     .. math::
 
@@ -566,11 +567,11 @@ def gravity_ee(easting, northing, upward, prism, density):
     are the shifted coordinates of the prism boundaries and :math:`G` is the
     Universal Gravitational Constant.
 
-    The :math:`\text{arctan2}` function is defined as follows:
+    The :math:`\operatorname{safe-arctan}` function is defined as follows:
 
     .. math::
 
-        \text{arctan2} \left( \frac{y}{x} \right) =
+        \operatorname{safe-arctan} \left( y, x \right) =
         \begin{cases}
             \text{arctan}\left( \frac{y}{x} \right) & x \ne 0 \\
             \frac{\pi}{2} & x = 0 \quad \text{and} \quad y > 0 \\
@@ -646,7 +647,8 @@ def gravity_nn(easting, northing, upward, prism, density):
 
     .. math::
 
-        k_{yy}(x, y, z) = - \text{arctan2} \left( \frac{zx}{yr} \right),
+        k_{yy}(x, y, z) =
+            - \operatorname{safe-arctan} \left( zx, yr \right),
 
     .. math::
 
@@ -666,11 +668,11 @@ def gravity_nn(easting, northing, upward, prism, density):
     are the shifted coordinates of the prism boundaries and :math:`G` is the
     Universal Gravitational Constant.
 
-    The :math:`\text{arctan2}` function is defined as follows:
+    The :math:`\operatorname{safe-arctan}` function is defined as follows:
 
     .. math::
 
-        \text{arctan2} \left( \frac{y}{x} \right) =
+        \operatorname{safe-arctan} \left( y, x \right) =
         \begin{cases}
             \text{arctan}\left( \frac{y}{x} \right) & x \ne 0 \\
             \frac{\pi}{2} & x = 0 \quad \text{and} \quad y > 0 \\
@@ -746,7 +748,8 @@ def gravity_uu(easting, northing, upward, prism, density):
 
     .. math::
 
-        k_{zz}(x, y, z) = - \text{arctan2} \left( \frac{xy}{zr} \right),
+        k_{zz}(x, y, z) =
+            - \operatorname{safe-arctan} \left( xy, zr \right),
 
     .. math::
 
@@ -766,11 +769,11 @@ def gravity_uu(easting, northing, upward, prism, density):
     are the shifted coordinates of the prism boundaries and :math:`G` is the
     Universal Gravitational Constant.
 
-    The :math:`\text{arctan2}` function is defined as follows:
+    The :math:`\operatorname{safe-arctan}` function is defined as follows:
 
     .. math::
 
-        \text{arctan2} \left( \frac{y}{x} \right) =
+        \operatorname{safe-arctan} \left( y, x \right) =
         \begin{cases}
             \text{arctan}\left( \frac{y}{x} \right) & x \ne 0 \\
             \frac{\pi}{2} & x = 0 \quad \text{and} \quad y > 0 \\

--- a/choclo/prism/_kernels.py
+++ b/choclo/prism/_kernels.py
@@ -795,16 +795,15 @@ def _safe_atan2(y, x):
     ----------
     - [Fukushima2020]_
     """
-    if x != 0:
-        result = np.arctan(y / x)
-    else:
+    if x == 0:
         if y > 0:
             result = np.pi / 2
         elif y < 0:
             result = -np.pi / 2
         else:
             result = 0
-    return result
+        return result
+    return np.arctan(y / x)
 
 
 @jit(nopython=True)

--- a/choclo/prism/_kernels.py
+++ b/choclo/prism/_kernels.py
@@ -58,9 +58,9 @@ def kernel_pot(easting, northing, upward, radius):
             x y \, \operatorname{safe-ln} (z + r)
             + y z \, \operatorname{safe-ln} (x + r)
             + z x \, \operatorname{safe-ln} (y + r) \\
-            & - \frac{x^2}{2} \text{arctan2} \left( \frac{yz}{xr} \right)
-            - \frac{y^2}{2} \text{arctan2} \left( \frac{zx}{yr} \right)
-            - \frac{z^2}{2} \text{arctan2} \left( \frac{xy}{zr} \right)
+            & - \frac{x^2}{2} \text{safe-arctan} \left( yz, xr \right)
+            - \frac{y^2}{2} \text{safe-arctan} \left( zx, yr \right)
+            - \frac{z^2}{2} \text{safe-arctan} \left( xy, zr \right)
 
     where
 
@@ -76,7 +76,7 @@ def kernel_pot(easting, northing, upward, radius):
 
     .. math::
 
-        \text{arctan2} \left( \frac{y}{x} \right) =
+        \text{safe-arctan} \left( y, x \right) =
         \begin{cases}
             \text{arctan}\left( \frac{y}{x} \right) & x \ne 0 \\
             \frac{\pi}{2} & x = 0 \quad \text{and} \quad y > 0 \\
@@ -149,7 +149,7 @@ def kernel_e(easting, northing, upward, radius):
             -\left[
             y \, \operatorname{safe-ln} (z + r)
             + z \, \operatorname{safe-ln} (y + r)
-            - x \, \text{arctan2} \left( \frac{yz}{xr} \right)
+            - x \, \text{safe-arctan} \left( yz, xr \right)
             \right]
 
     where
@@ -166,7 +166,7 @@ def kernel_e(easting, northing, upward, radius):
 
     .. math::
 
-        \text{arctan2} \left( \frac{y}{x} \right) =
+        \text{safe-arctan} \left( y, x \right) =
         \begin{cases}
             \text{arctan}\left( \frac{y}{x} \right) & x \ne 0 \\
             \frac{\pi}{2} & x = 0 \quad \text{and} \quad y > 0 \\
@@ -242,7 +242,7 @@ def kernel_n(easting, northing, upward, radius):
             -\left[
             z \, \operatorname{safe-ln} (x + r)
             + x \, \operatorname{safe-ln} (z + r)
-            - y \, \text{arctan2} \left( \frac{zx}{yr} \right)
+            - y \, \text{safe-arctan} \left( zx, yr \right)
             \right]
 
     where
@@ -259,7 +259,7 @@ def kernel_n(easting, northing, upward, radius):
 
     .. math::
 
-        \text{arctan2} \left( \frac{y}{x} \right) =
+        \text{safe-arctan} \left( y, x \right) =
         \begin{cases}
             \text{arctan}\left( \frac{y}{x} \right) & x \ne 0 \\
             \frac{\pi}{2} & x = 0 \quad \text{and} \quad y > 0 \\
@@ -335,7 +335,7 @@ def kernel_u(easting, northing, upward, radius):
             - \left[
             x \, \operatorname{safe-ln} (y + r)
             + y \, \operatorname{safe-ln} (x + r)
-            - z \, \text{arctan2} \left( \frac{xy}{zr} \right)
+            - z \, \text{safe-arctan} \left( xy, zr \right)
             \right]
 
     where
@@ -352,7 +352,7 @@ def kernel_u(easting, northing, upward, radius):
 
     .. math::
 
-        \text{arctan2} \left( \frac{y}{x} \right) =
+        \text{safe-arctan} \left( y, x \right) =
         \begin{cases}
             \text{arctan}\left( \frac{y}{x} \right) & x \ne 0 \\
             \frac{\pi}{2} & x = 0 \quad \text{and} \quad y > 0 \\
@@ -425,13 +425,13 @@ def kernel_ee(easting, northing, upward, radius):
 
     .. math::
 
-        k_{xx}(x, y, z) = - \text{arctan2} \left( \frac{yz}{xr} \right)
+        k_{xx}(x, y, z) = - \text{safe-arctan} \left( yz, xr \right)
 
     where
 
     .. math::
 
-        \text{arctan2} \left( \frac{y}{x} \right) =
+        \text{safe-arctan} \left( y, x \right) =
         \begin{cases}
             \text{arctan}\left( \frac{y}{x} \right) & x \ne 0 \\
             \frac{\pi}{2} & x = 0 \quad \text{and} \quad y > 0 \\
@@ -490,13 +490,13 @@ def kernel_nn(easting, northing, upward, radius):
 
     .. math::
 
-        k_{yy}(x, y, z) = - \text{arctan2} \left( \frac{zx}{yr} \right)
+        k_{yy}(x, y, z) = - \text{safe-arctan} \left( zx, yr \right)
 
     where
 
     .. math::
 
-        \text{arctan2} \left( \frac{y}{x} \right) =
+        \text{safe-arctan} \left( y, x \right) =
         \begin{cases}
             \text{arctan}\left( \frac{y}{x} \right) & x \ne 0 \\
             \frac{\pi}{2} & x = 0 \quad \text{and} \quad y > 0 \\
@@ -555,13 +555,13 @@ def kernel_uu(easting, northing, upward, radius):
 
     .. math::
 
-        k_{zz}(x, y, z) = - \text{arctan2} \left( \frac{xy}{zr} \right)
+        k_{zz}(x, y, z) = - \text{safe-arctan} \left( xy, zr \right)
 
     where
 
     .. math::
 
-        \text{arctan2} \left( \frac{y}{x} \right) =
+        \text{safe-arctan} \left( y, x \right) =
         \begin{cases}
             \text{arctan}\left( \frac{y}{x} \right) & x \ne 0 \\
             \frac{\pi}{2} & x = 0 \quad \text{and} \quad y > 0 \\
@@ -783,7 +783,7 @@ def _safe_atan2(y, x):
 
     .. math::
 
-        \text{arctan2} \left( \frac{y}{x} \right) =
+        \operatorname{safe-arctan} \left(y, x\right) =
         \begin{cases}
             \text{arctan}\left( \frac{y}{x} \right) & x \ne 0 \\
             \frac{\pi}{2} & x = 0 \quad \text{and} \quad y > 0 \\

--- a/choclo/prism/_kernels.py
+++ b/choclo/prism/_kernels.py
@@ -58,9 +58,9 @@ def kernel_pot(easting, northing, upward, radius):
             x y \, \operatorname{safe-ln} (z + r)
             + y z \, \operatorname{safe-ln} (x + r)
             + z x \, \operatorname{safe-ln} (y + r) \\
-            & - \frac{x^2}{2} \text{safe-arctan} \left( yz, xr \right)
-            - \frac{y^2}{2} \text{safe-arctan} \left( zx, yr \right)
-            - \frac{z^2}{2} \text{safe-arctan} \left( xy, zr \right)
+            & - \frac{x^2}{2} \operatorname{safe-arctan} \left( yz, xr \right)
+            - \frac{y^2}{2} \operatorname{safe-arctan} \left( zx, yr \right)
+            - \frac{z^2}{2} \operatorname{safe-arctan} \left( xy, zr \right)
 
     where
 
@@ -76,7 +76,7 @@ def kernel_pot(easting, northing, upward, radius):
 
     .. math::
 
-        \text{safe-arctan} \left( y, x \right) =
+        \operatorname{safe-arctan} \left( y, x \right) =
         \begin{cases}
             \text{arctan}\left( \frac{y}{x} \right) & x \ne 0 \\
             \frac{\pi}{2} & x = 0 \quad \text{and} \quad y > 0 \\
@@ -149,7 +149,7 @@ def kernel_e(easting, northing, upward, radius):
             -\left[
             y \, \operatorname{safe-ln} (z + r)
             + z \, \operatorname{safe-ln} (y + r)
-            - x \, \text{safe-arctan} \left( yz, xr \right)
+            - x \, \operatorname{safe-arctan} \left( yz, xr \right)
             \right]
 
     where
@@ -166,7 +166,7 @@ def kernel_e(easting, northing, upward, radius):
 
     .. math::
 
-        \text{safe-arctan} \left( y, x \right) =
+        \operatorname{safe-arctan} \left( y, x \right) =
         \begin{cases}
             \text{arctan}\left( \frac{y}{x} \right) & x \ne 0 \\
             \frac{\pi}{2} & x = 0 \quad \text{and} \quad y > 0 \\
@@ -242,7 +242,7 @@ def kernel_n(easting, northing, upward, radius):
             -\left[
             z \, \operatorname{safe-ln} (x + r)
             + x \, \operatorname{safe-ln} (z + r)
-            - y \, \text{safe-arctan} \left( zx, yr \right)
+            - y \, \operatorname{safe-arctan} \left( zx, yr \right)
             \right]
 
     where
@@ -259,7 +259,7 @@ def kernel_n(easting, northing, upward, radius):
 
     .. math::
 
-        \text{safe-arctan} \left( y, x \right) =
+        \operatorname{safe-arctan} \left( y, x \right) =
         \begin{cases}
             \text{arctan}\left( \frac{y}{x} \right) & x \ne 0 \\
             \frac{\pi}{2} & x = 0 \quad \text{and} \quad y > 0 \\
@@ -335,7 +335,7 @@ def kernel_u(easting, northing, upward, radius):
             - \left[
             x \, \operatorname{safe-ln} (y + r)
             + y \, \operatorname{safe-ln} (x + r)
-            - z \, \text{safe-arctan} \left( xy, zr \right)
+            - z \, \operatorname{safe-arctan} \left( xy, zr \right)
             \right]
 
     where
@@ -352,7 +352,7 @@ def kernel_u(easting, northing, upward, radius):
 
     .. math::
 
-        \text{safe-arctan} \left( y, x \right) =
+        \operatorname{safe-arctan} \left( y, x \right) =
         \begin{cases}
             \text{arctan}\left( \frac{y}{x} \right) & x \ne 0 \\
             \frac{\pi}{2} & x = 0 \quad \text{and} \quad y > 0 \\
@@ -425,13 +425,13 @@ def kernel_ee(easting, northing, upward, radius):
 
     .. math::
 
-        k_{xx}(x, y, z) = - \text{safe-arctan} \left( yz, xr \right)
+        k_{xx}(x, y, z) = - \operatorname{safe-arctan} \left( yz, xr \right)
 
     where
 
     .. math::
 
-        \text{safe-arctan} \left( y, x \right) =
+        \operatorname{safe-arctan} \left( y, x \right) =
         \begin{cases}
             \text{arctan}\left( \frac{y}{x} \right) & x \ne 0 \\
             \frac{\pi}{2} & x = 0 \quad \text{and} \quad y > 0 \\
@@ -490,13 +490,13 @@ def kernel_nn(easting, northing, upward, radius):
 
     .. math::
 
-        k_{yy}(x, y, z) = - \text{safe-arctan} \left( zx, yr \right)
+        k_{yy}(x, y, z) = - \operatorname{safe-arctan} \left( zx, yr \right)
 
     where
 
     .. math::
 
-        \text{safe-arctan} \left( y, x \right) =
+        \operatorname{safe-arctan} \left( y, x \right) =
         \begin{cases}
             \text{arctan}\left( \frac{y}{x} \right) & x \ne 0 \\
             \frac{\pi}{2} & x = 0 \quad \text{and} \quad y > 0 \\
@@ -555,13 +555,13 @@ def kernel_uu(easting, northing, upward, radius):
 
     .. math::
 
-        k_{zz}(x, y, z) = - \text{safe-arctan} \left( xy, zr \right)
+        k_{zz}(x, y, z) = - \operatorname{safe-arctan} \left( xy, zr \right)
 
     where
 
     .. math::
 
-        \text{safe-arctan} \left( y, x \right) =
+        \operatorname{safe-arctan} \left( y, x \right) =
         \begin{cases}
             \text{arctan}\left( \frac{y}{x} \right) & x \ne 0 \\
             \frac{\pi}{2} & x = 0 \quad \text{and} \quad y > 0 \\

--- a/choclo/prism/_kernels.py
+++ b/choclo/prism/_kernels.py
@@ -840,7 +840,7 @@ def _safe_log(x, r):
         return 0
     if x < 0:
         if r == -x:
-            result = -np.log(np.abs(x))
+            result = -np.log(-2 * x)
         else:
             result = np.log((r**2 - x**2) / (r - x))
         return result

--- a/choclo/prism/_kernels.py
+++ b/choclo/prism/_kernels.py
@@ -825,7 +825,7 @@ def _safe_log(x, r):
         \text{safe_ln}(x, r) =
         \begin{cases}
             0 & x = 0, r = 0 \\
-            \ln(x + r) & x > 0 \\
+            \ln(x + r) & x \ge 0 \\
             \ln((r^2 - x^2) / (r - x)) & x < 0, r \ne -x \\
             \ln(10^{-10}\text{m} / (r - x)) & x < 0, r = -x
         \end{cases}

--- a/choclo/prism/_kernels.py
+++ b/choclo/prism/_kernels.py
@@ -836,7 +836,7 @@ def _safe_log(x, r):
     ----------
     - [Fukushima2020]_
     """
-    if x == 0 and r == 0:
+    if r == 0:
         return 0
     if x < 0:
         if r == -x:

--- a/choclo/prism/_kernels.py
+++ b/choclo/prism/_kernels.py
@@ -55,9 +55,9 @@ def kernel_pot(easting, northing, upward, radius):
     .. math::
 
         k_V(x, y, z) &=
-            x y \, \text{ln2} (z + r)
-            + y z \, \text{ln2} (x + r)
-            + z x \, \text{ln2} (y + r) \\
+            x y \, \operatorname{safe-ln} (z + r)
+            + y z \, \operatorname{safe-ln} (x + r)
+            + z x \, \operatorname{safe-ln} (y + r) \\
             & - \frac{x^2}{2} \text{arctan2} \left( \frac{yz}{xr} \right)
             - \frac{y^2}{2} \text{arctan2} \left( \frac{zx}{yr} \right)
             - \frac{z^2}{2} \text{arctan2} \left( \frac{xy}{zr} \right)
@@ -66,7 +66,7 @@ def kernel_pot(easting, northing, upward, radius):
 
     .. math::
 
-        \text{ln2}(x) =
+        \operatorname{safe-ln}(x) =
         \begin{cases}
             0 & |x| < 10^{-10} \\
             \ln (x)
@@ -147,8 +147,8 @@ def kernel_e(easting, northing, upward, radius):
 
         k_x(x, y, z) =
             -\left[
-            y \, \text{ln2} (z + r)
-            + z \, \text{ln2} (y + r)
+            y \, \operatorname{safe-ln} (z + r)
+            + z \, \operatorname{safe-ln} (y + r)
             - x \, \text{arctan2} \left( \frac{yz}{xr} \right)
             \right]
 
@@ -156,7 +156,7 @@ def kernel_e(easting, northing, upward, radius):
 
     .. math::
 
-        \text{ln2}(x) =
+        \operatorname{safe-ln}(x) =
         \begin{cases}
             0 & |x| < 10^{-10} \\
             \ln (x)
@@ -240,8 +240,8 @@ def kernel_n(easting, northing, upward, radius):
 
         k_y(x, y, z) =
             -\left[
-            z \, \text{ln2} (x + r)
-            + x \, \text{ln2} (z + r)
+            z \, \operatorname{safe-ln} (x + r)
+            + x \, \operatorname{safe-ln} (z + r)
             - y \, \text{arctan2} \left( \frac{zx}{yr} \right)
             \right]
 
@@ -249,7 +249,7 @@ def kernel_n(easting, northing, upward, radius):
 
     .. math::
 
-        \text{ln2}(x) =
+        \operatorname{safe-ln}(x) =
         \begin{cases}
             0 & |x| < 10^{-10} \\
             \ln (x)
@@ -333,8 +333,8 @@ def kernel_u(easting, northing, upward, radius):
 
         k_z(x, y, z) =
             - \left[
-            x \, \text{ln2} (y + r)
-            + y \, \text{ln2} (x + r)
+            x \, \operatorname{safe-ln} (y + r)
+            + y \, \operatorname{safe-ln} (x + r)
             - z \, \text{arctan2} \left( \frac{xy}{zr} \right)
             \right]
 
@@ -342,7 +342,7 @@ def kernel_u(easting, northing, upward, radius):
 
     .. math::
 
-        \text{ln2}(x) =
+        \operatorname{safe-ln}(x) =
         \begin{cases}
             0 & |x| < 10^{-10} \\
             \ln (x)
@@ -620,13 +620,13 @@ def kernel_en(easting, northing, upward, radius):
 
     .. math::
 
-        k_{xy}(x, y, z) = \text{ln2} \left( z + r \right)
+        k_{xy}(x, y, z) = \operatorname{safe-ln} \left( z + r \right)
 
     where
 
     .. math::
 
-        \text{ln2}(x) =
+        \operatorname{safe-ln}(x) =
         \begin{cases}
             0 & |x| < 10^{-10} \\
             \ln (x)
@@ -683,13 +683,13 @@ def kernel_eu(easting, northing, upward, radius):
 
     .. math::
 
-        k_{xz}(x, y, z) = \text{ln2} \left( y + r \right)
+        k_{xz}(x, y, z) = \operatorname{safe-ln} \left( y + r \right)
 
     where
 
     .. math::
 
-        \text{ln2}(x) =
+        \operatorname{safe-ln}(x) =
         \begin{cases}
             0 & |x| < 10^{-10} \\
             \ln (x)
@@ -746,13 +746,13 @@ def kernel_nu(easting, northing, upward, radius):
 
     .. math::
 
-        k_{yz}(x, y, z) = \text{ln2} \left( x + r \right)
+        k_{yz}(x, y, z) = \operatorname{safe-ln} \left( x + r \right)
 
     where
 
     .. math::
 
-        \text{ln2}(x) =
+        \operatorname{safe-ln}(x) =
         \begin{cases}
             0 & |x| < 10^{-10} \\
             \ln (x)

--- a/choclo/prism/_kernels.py
+++ b/choclo/prism/_kernels.py
@@ -815,10 +815,6 @@ def _safe_log(x, r):
     coordinate of the prism vertex and :math:`r` is the Euclidean distance
     (always non-negative) from the vertex to the observation point.
 
-    Evaluating :math:`\ln{x + r}` when :math:`x<0` and :math:`r` is really
-    close to :math:`|x|` could lead to high numerical errors. For those cases
-    this function returns a modified version to reduce those numerical errors:
-
     .. math::
 
         \text{safe_ln}(x, r) =
@@ -826,10 +822,16 @@ def _safe_log(x, r):
             0 & x = 0, r = 0 \\
             \ln(x + r) & x \ge 0 \\
             \ln((r^2 - x^2) / (r - x)) & x < 0, r \ne -x \\
-            \ln(10^{-10}\text{m} / (r - x)) & x < 0, r = -x
+            -\ln(-2 x) & x < 0, r = -x
         \end{cases}
 
-    This modified function is based on the one proposed by [Fukushima2020]_.
+    This function returns 0 when the observation point is located on the vertex
+    of the prism (:math:`r=0`); and two modified versions in case that
+    :math:`x` is negative: if :math:`x = -r` then the :math:`\ln{x + r}` can be
+    replaced by :math:`-\ln{|x| + r} = -\ln(-2x)`, and for any other negative
+    value of :math:`x` it returns :math:`\ln((r^2 - x^2) / (r - x))` which
+    helps by reducing the floating point errors ([Fukushima2020_]).
+    This modified version was inspired by [Nagy2000] and [Fukushima2020_]:
 
     References
     ----------

--- a/choclo/prism/_kernels.py
+++ b/choclo/prism/_kernels.py
@@ -840,9 +840,8 @@ def _safe_log(x, r):
         return 0
     if x < 0:
         if r == -x:
-            # approximate zero length by a 1 Angstrom
-            diff_squares = 1e-10
+            result = -np.log(np.abs(x))
         else:
-            diff_squares = r**2 - x**2
-        return np.log(diff_squares / (r - x))
+            result = np.log((r**2 - x**2) / (r - x))
+        return result
     return np.log(x + r)

--- a/choclo/tests/test_prism_gravity.py
+++ b/choclo/tests/test_prism_gravity.py
@@ -1160,3 +1160,65 @@ class TestNonDiagonalTensor:
         # Check if all values in g_en have the same sign
         signs = np.sign(g_en)
         npt.assert_allclose(signs[0], signs)
+
+    @pytest.mark.parametrize("easting_boundary", (0, 1))
+    @pytest.mark.parametrize("upward_boundary", (4, 5))
+    def test_g_eu_north_vertices(
+        self, prism, density, easting_boundary, upward_boundary
+    ):
+        """
+        Test values of g_eu on observation points north the nodes
+
+        If the safe_log function is not properly defined, the values of g_eu at
+        the north of the nodes (but with different northing coordinate) should
+        be wrong: they will have a different sign.
+        """
+        vertex_easting = prism[easting_boundary]
+        vertex_upward = prism[upward_boundary]
+        # Consider an observation point at the north of one of the vertex of
+        # the prism and define a few observation points around it
+        easting = np.linspace(vertex_easting - 3, vertex_easting + 3, 61)
+        upward = np.linspace(vertex_upward - 3, vertex_upward + 3, 61)
+        assert vertex_easting in easting and vertex_upward in upward
+        northing = prism[3] + 1  # locate the observation points north the prism
+        g_eu = np.array(
+            [
+                gravity_eu(e, northing, u, prism, density)
+                for e in easting
+                for u in upward
+            ]
+        )
+        # Check if all values in g_eu have the same sign
+        signs = np.sign(g_eu)
+        npt.assert_allclose(signs[0], signs)
+
+    @pytest.mark.parametrize("northing_boundary", (2, 3))
+    @pytest.mark.parametrize("upward_boundary", (4, 5))
+    def test_g_nu_north_vertices(
+        self, prism, density, northing_boundary, upward_boundary
+    ):
+        """
+        Test values of g_nu on observation points north the nodes
+
+        If the safe_log function is not properly defined, the values of g_nu at
+        the east of the nodes (but with different easting coordinate) should be
+        wrong: they will have a different sign.
+        """
+        vertex_northing = prism[northing_boundary]
+        vertex_upward = prism[upward_boundary]
+        # Consider an observation point at the east of one of the vertex of
+        # the prism and define a few observation points around it
+        northing = np.linspace(vertex_northing - 3, vertex_northing + 3, 61)
+        upward = np.linspace(vertex_upward - 3, vertex_upward + 3, 61)
+        assert vertex_northing in northing and vertex_upward in upward
+        easting = prism[1] + 1  # locate the observation points north the prism
+        g_nu = np.array(
+            [
+                gravity_nu(easting, n, u, prism, density)
+                for n in northing
+                for u in upward
+            ]
+        )
+        # Check if all values in g_nu have the same sign
+        signs = np.sign(g_nu)
+        npt.assert_allclose(signs[0], signs)

--- a/choclo/tests/test_prism_gravity.py
+++ b/choclo/tests/test_prism_gravity.py
@@ -1222,3 +1222,120 @@ class TestNonDiagonalTensor:
         # Check if all values in g_nu have the same sign
         signs = np.sign(g_nu)
         npt.assert_allclose(signs[0], signs)
+
+
+class TestTensorSymmetry:
+    """
+    Test symmetry of tensor components
+
+    Each test will compute one tensor component on two regular grids. Each grid
+    falls in one of two parallel planes that are equidistant to the prism. The
+    grids will contain observation points that share a pair of coordinates
+    with the vertices of the prism to test symmetry on those regions.
+    For example, for `g_en` two horizontal grids will be defined: one above and
+    one below the prism. The first one will contain points that fall right
+    above its vertices, while the second one will contain points that fall
+    right below them (these points share the easting and northing coordinates
+    with these vertices).
+
+    For the non-diagonal tensor components these points are where the
+    modifications of the log functions take protagonism.
+    """
+
+    atol = 1e-18
+
+    @pytest.fixture(name="prism")
+    def prism(self):
+        prism = [-10, 10, -20, 20, -30, 30]
+        return np.array(prism, dtype=np.float64)
+
+    @pytest.fixture(name="density")
+    def density(self):
+        return 400.0
+
+    def test_g_en_symmetry(self, prism, density):
+        """
+        Test symmetry of g_en
+        """
+        west, east, south, north, bottom, top = prism[:]
+        # Define two horizontal grids
+        # (make sure that contain points that fall above and below the
+        # vertices)
+        easting = np.linspace(-40, 40, 41)
+        northing = np.linspace(-40, 40, 41)
+        assert west in easting and east in easting
+        assert south in northing and north in northing
+        delta = 2
+        g_en_top = np.array(
+            [
+                gravity_en(e, n, top + delta, prism, density)
+                for e in easting
+                for n in northing
+            ]
+        )
+        g_en_bottom = np.array(
+            [
+                gravity_en(e, n, bottom - delta, prism, density)
+                for e in easting
+                for n in northing
+            ]
+        )
+        npt.assert_allclose(g_en_top, g_en_bottom, atol=self.atol)
+
+    def test_g_eu_symmetry(self, prism, density):
+        """
+        Test symmetry of g_eu
+        """
+        west, east, south, north, bottom, top = prism[:]
+        # Define two vertical grids parallel to the easting-upward plane
+        # (make sure that contain points that fall north and south the
+        # vertices)
+        easting = np.linspace(-40, 40, 41)
+        upward = np.linspace(-40, 40, 41)
+        assert west in easting and east in easting
+        assert bottom in upward and top in upward
+        delta = 2
+        g_eu_north = np.array(
+            [
+                gravity_eu(e, north + delta, u, prism, density)
+                for e in easting
+                for u in upward
+            ]
+        )
+        g_eu_south = np.array(
+            [
+                gravity_eu(e, south - delta, u, prism, density)
+                for e in easting
+                for u in upward
+            ]
+        )
+        npt.assert_allclose(g_eu_north, g_eu_south, atol=self.atol)
+
+    def test_g_nu_symmetry(self, prism, density):
+        """
+        Test symmetry of g_nu
+        """
+        west, east, south, north, bottom, top = prism[:]
+        # Define two vertical grids parallel to the northing-upward plane
+        # (make sure that contain points that fall north and south the
+        # vertices)
+        northing = np.linspace(-40, 40, 41)
+        upward = np.linspace(-40, 40, 41)
+        assert south in northing and north in northing
+        assert bottom in upward and top in upward
+        delta = 2
+        g_nu_north = np.array(
+            [
+                gravity_nu(east + delta, n, u, prism, density)
+                for n in northing
+                for u in upward
+            ]
+        )
+        g_nu_south = np.array(
+            [
+                gravity_nu(west - delta, n, u, prism, density)
+                for n in northing
+                for u in upward
+            ]
+        )
+        npt.assert_allclose(g_nu_north, g_nu_south, atol=self.atol)

--- a/choclo/tests/test_prism_gravity.py
+++ b/choclo/tests/test_prism_gravity.py
@@ -1114,3 +1114,74 @@ class TestLaplacian:
             npt.assert_allclose(-g_nn, g_ee + g_uu)
         if left_component == "g_uu":
             npt.assert_allclose(-g_uu, g_ee + g_nn)
+
+
+class TestNonDiagonalTensor:
+    """
+    Test if non diagonal tensor components misbehave on some regions
+    """
+
+    @pytest.fixture(name="prism")
+    def prism(self):
+        prism = [-10, 10, -20, 20, -50, -15]
+        return np.array(prism, dtype=np.float64)
+
+    @pytest.fixture(name="density")
+    def density(self):
+        return 400.0
+
+    @pytest.mark.parametrize("easting_boundary", (0, 1))
+    @pytest.mark.parametrize("northing_boundary", (2, 3))
+    def test_g_en_above_vertices_easting_direction(
+        self, prism, density, easting_boundary, northing_boundary
+    ):
+        """
+        Test values of g_en on observation points above the nodes
+
+        If the safe_log function is not properly defined, the values of g_en
+        above the nodes (but with different upward coordinate) are wrong: they
+        even have a different sign.
+
+        This function runs the test with a set of coordinates along the easting
+        direction.
+        """
+        vertex_easting = prism[easting_boundary]
+        vertex_northing = prism[northing_boundary]
+        # Define an easting linspace that contains the coordinate of one of the
+        # nodes of the prism
+        easting = np.linspace(vertex_easting - 3, vertex_easting + 3, 61)
+        upward = 0
+        g_en = np.array(
+            [gravity_en(e, vertex_northing, upward, prism, density) for e in easting]
+        )
+        # Check if all values in g_en have the same sign
+        signs = np.sign(g_en)
+        npt.assert_allclose(signs[0], signs)
+
+    @pytest.mark.parametrize("easting_boundary", (0, 1))
+    @pytest.mark.parametrize("northing_boundary", (2, 3))
+    def test_g_en_above_vertices_northing_direction(
+        self, prism, density, easting_boundary, northing_boundary
+    ):
+        """
+        Test values of g_en on observation points above the nodes
+
+        If the safe_log function is not properly defined, the values of g_en
+        above the nodes (but with different upward coordinate) are wrong: they
+        even have a different sign.
+
+        This function runs the test with a set of coordinates along the
+        northing direction.
+        """
+        vertex_easting = prism[easting_boundary]
+        vertex_northing = prism[northing_boundary]
+        # Define an easting linspace that contains the coordinate of one of the
+        # nodes of the prism
+        northing = np.linspace(vertex_northing - 3, vertex_northing + 3, 61)
+        upward = 0
+        g_en = np.array(
+            [gravity_en(vertex_easting, n, upward, prism, density) for n in northing]
+        )
+        # Check if all values in g_en have the same sign
+        signs = np.sign(g_en)
+        npt.assert_allclose(signs[0], signs)

--- a/choclo/tests/test_prism_gravity.py
+++ b/choclo/tests/test_prism_gravity.py
@@ -1132,55 +1132,30 @@ class TestNonDiagonalTensor:
 
     @pytest.mark.parametrize("easting_boundary", (0, 1))
     @pytest.mark.parametrize("northing_boundary", (2, 3))
-    def test_g_en_above_vertices_easting_direction(
+    def test_g_en_above_vertices(
         self, prism, density, easting_boundary, northing_boundary
     ):
         """
         Test values of g_en on observation points above the nodes
 
         If the safe_log function is not properly defined, the values of g_en
-        above the nodes (but with different upward coordinate) are wrong: they
-        even have a different sign.
-
-        This function runs the test with a set of coordinates along the easting
-        direction.
+        above the nodes (but with different upward coordinate) should be wrong:
+        they will have a different sign.
         """
         vertex_easting = prism[easting_boundary]
         vertex_northing = prism[northing_boundary]
-        # Define an easting linspace that contains the coordinate of one of the
-        # nodes of the prism
+        # Consider an observation point above one of the vertex of the prism
+        # and define a few observation points around it
         easting = np.linspace(vertex_easting - 3, vertex_easting + 3, 61)
-        upward = 0
-        g_en = np.array(
-            [gravity_en(e, vertex_northing, upward, prism, density) for e in easting]
-        )
-        # Check if all values in g_en have the same sign
-        signs = np.sign(g_en)
-        npt.assert_allclose(signs[0], signs)
-
-    @pytest.mark.parametrize("easting_boundary", (0, 1))
-    @pytest.mark.parametrize("northing_boundary", (2, 3))
-    def test_g_en_above_vertices_northing_direction(
-        self, prism, density, easting_boundary, northing_boundary
-    ):
-        """
-        Test values of g_en on observation points above the nodes
-
-        If the safe_log function is not properly defined, the values of g_en
-        above the nodes (but with different upward coordinate) are wrong: they
-        even have a different sign.
-
-        This function runs the test with a set of coordinates along the
-        northing direction.
-        """
-        vertex_easting = prism[easting_boundary]
-        vertex_northing = prism[northing_boundary]
-        # Define an easting linspace that contains the coordinate of one of the
-        # nodes of the prism
         northing = np.linspace(vertex_northing - 3, vertex_northing + 3, 61)
-        upward = 0
+        assert vertex_easting in easting and vertex_northing in northing
+        upward = prism[5] + 1  # locate the observation points above the prism
         g_en = np.array(
-            [gravity_en(vertex_easting, n, upward, prism, density) for n in northing]
+            [
+                gravity_en(e, n, upward, prism, density)
+                for e in easting
+                for n in northing
+            ]
         )
         # Check if all values in g_en have the same sign
         signs = np.sign(g_en)

--- a/choclo/tests/test_prism_gravity.py
+++ b/choclo/tests/test_prism_gravity.py
@@ -1118,7 +1118,24 @@ class TestLaplacian:
 
 class TestNonDiagonalTensor:
     """
-    Test if non diagonal tensor components misbehave on some regions
+    Test the behaviour of non-diagonal tensor components on critical points
+
+    The non-diagonal tensor components evaluate the log function on
+    ``log(x + r)``, where ``x`` is the shifted coordinate of the vertex and
+    ``r`` is the distance between the vertex and the computation point. When
+    the two other shifted coordinates are zero and ``x`` is negative, then
+    ``x == -r``, making impossible to evaluate the log function.
+    The ``_safe_log`` function accounts for this and safely evaluate the log
+    function in these points.
+
+    If we consider for example the ``g_en`` component, then observation points
+    that fall above one of the vertices of the prism lead to this situation. If
+    the ``_safe_log`` function is not properly defined, then the value of
+    ``g_en`` on those points will be significantly different from the
+    surrounding points, even with a different sign.
+
+    The following test functions compare the values of the non-diagonal
+    components on and around these particular observation points.
     """
 
     @pytest.fixture(name="prism")
@@ -1136,11 +1153,7 @@ class TestNonDiagonalTensor:
         self, prism, density, easting_boundary, northing_boundary
     ):
         """
-        Test values of g_en on observation points above the nodes
-
-        If the safe_log function is not properly defined, the values of g_en
-        above the nodes (but with different upward coordinate) should be wrong:
-        they will have a different sign.
+        Test g_en on an observation point above the node and around it
         """
         vertex_easting = prism[easting_boundary]
         vertex_northing = prism[northing_boundary]
@@ -1167,11 +1180,7 @@ class TestNonDiagonalTensor:
         self, prism, density, easting_boundary, upward_boundary
     ):
         """
-        Test values of g_eu on observation points north the nodes
-
-        If the safe_log function is not properly defined, the values of g_eu at
-        the north of the nodes (but with different northing coordinate) should
-        be wrong: they will have a different sign.
+        Test g_eu on an observation point north the node and around it
         """
         vertex_easting = prism[easting_boundary]
         vertex_upward = prism[upward_boundary]
@@ -1198,11 +1207,7 @@ class TestNonDiagonalTensor:
         self, prism, density, northing_boundary, upward_boundary
     ):
         """
-        Test values of g_nu on observation points east the nodes
-
-        If the safe_log function is not properly defined, the values of g_nu at
-        the east of the nodes (but with different easting coordinate) should be
-        wrong: they will have a different sign.
+        Test g_nu on an observation point north the node and around it
         """
         vertex_northing = prism[northing_boundary]
         vertex_upward = prism[upward_boundary]

--- a/choclo/tests/test_prism_gravity.py
+++ b/choclo/tests/test_prism_gravity.py
@@ -1194,11 +1194,11 @@ class TestNonDiagonalTensor:
 
     @pytest.mark.parametrize("northing_boundary", (2, 3))
     @pytest.mark.parametrize("upward_boundary", (4, 5))
-    def test_g_nu_north_vertices(
+    def test_g_nu_east_vertices(
         self, prism, density, northing_boundary, upward_boundary
     ):
         """
-        Test values of g_nu on observation points north the nodes
+        Test values of g_nu on observation points east the nodes
 
         If the safe_log function is not properly defined, the values of g_nu at
         the east of the nodes (but with different easting coordinate) should be


### PR DESCRIPTION
Fix a bug on the non-diagonal tensor components of the prism due to a wrong
evaluation of the logarithmic function. Add two tests that catch the bug on the
g_en component. Correctly evaluate the log function present in the non-diagonal
tensor components when the shifted coordinate `x` of the vertex is negative and
it's equal to the negative of the distance `r` between the vertex and the
computation point. In that case the `log(x + r)` can be replaced by
`-log(2|x|)`. Also, implement a modified version of the log function proposed
by Fukushima (2020) for cases where the shifted coordinate of the node is
negative but different than the negative of the distance: improves the accuracy
when evaluating the log function on very small values. Now the `_safe_log`
function takes two arguments instead of one: the shifted coordinate `x` and the
distance `r`.