### PR TITLE
Use Ubuntu 20.04 for testing with Python 3.6 in Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python: ["3.6", "3.10"]
         exclude: # There is no Python 3.6 available on Ubuntu 22.04
-          - os: ubuntu
+          - os: ubuntu-latest
             python: "3.6"
         include:
           - python: "3.6"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,13 +31,13 @@ jobs:
   # Run tests and upload to codecov
   test:
     name: ${{ matrix.os }} python=${{ matrix.python }} dependencies=${{ matrix.dependencies }}
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       # Otherwise, the workflow would stop if a single job fails. We want to
       # run all of them to catch failures in different combinations.
       fail-fast: false
       matrix:
-        os: [ubuntu, macos, windows]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python: ["3.6", "3.10"]
         exclude: # There is no Python 3.6 available on Ubuntu 22.04
           - os: ubuntu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,8 +39,14 @@ jobs:
       matrix:
         os: [ubuntu, macos, windows]
         python: ["3.6", "3.10"]
+        exclude: # There is no Python 3.6 available on Ubuntu 22.04
+          - os: ubuntu
+            python: "3.6"
         include:
           - python: "3.6"
+            dependencies: oldest
+          - python: "3.6" # add instance of Python 3.6 and Ubuntu 20.04
+            os: ubuntu-20.04
             dependencies: oldest
           - python: "3.10"
             dependencies: latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
           - python: "3.6"
             dependencies: oldest
           - python: "3.6" # add instance of Python 3.6 and Ubuntu 20.04
-            os: ubuntu-20.04
+            os: "ubuntu-20.04"
             dependencies: oldest
           - python: "3.10"
             dependencies: latest


### PR DESCRIPTION
Running tests on GitHub Actions with `ubuntu` uses Ubuntu 22.04 since
recently. 22.04 doesn't offer a candidate to install Python 3.6, so we
need to run them against the previous LTS version: 20.04.
