### PR TITLE
Add buttons to download overview page

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -298,3 +298,13 @@ Let's benchmark this function against the non-parallelized
 By distributing the load between multiple processors we were capable of
 lowering the computation time by a few more factors.
 
+----
+
+.. grid:: 2
+
+    .. grid-item-card:: :jupyter-download-script:`Download Python script <overview>`
+        :text-align: center
+
+    .. grid-item-card:: :jupyter-download-nb:`Download Jupyter notebook <overview>`
+        :text-align: center
+

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - sphinx-book-theme==0.3.*
   - sphinx-copybutton==0.5.*
   - sphinx-design==0.1.*
-  - jupyter-sphinx==0.3.*
+  - jupyter-sphinx==0.4.*
   # Style
   - black
   - pathspec


### PR DESCRIPTION
Use the `jupyter-sphinx` roles for downloading a documentation page as a script or as a jupyter notebook to create buttons for downloading the Overview page. Update version of `jupyter-sphinx` to `0.4.*`.
