### PR TITLE
Move "How to use Choclo" to its own user guide page

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -95,6 +95,7 @@ word *chuqllu*.
     :maxdepth: 1
     :caption: User Guide
 
+    user_guide/how-to-use.rst
     user_guide/jacobian.rst
 
 .. toctree::

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -60,243 +60,134 @@ example, :func:`choclo.prism.gravity_e` computes the easting component of the
 gravitational acceleration of a prism, while :func:`choclo.prism.gravity_ee`
 computes the easting-easting gravity tensor component.
 
+Gravity forward modelling
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-How to use Choclo
------------------
+Choclo offers functions to forward model the gravity fields of point masses and
+rectangular prisms.
 
-The simplest case
-~~~~~~~~~~~~~~~~~
-
-Using Choclo is very simple, but it requires some work from our side. Let's say
-we need to compute the upward component of the gravitational acceleration that
-a single rectangular prism produces on a single computation point. To do so we
-can just call the :func:`choclo.prism.gravity_u` function:
+For example, we can compute the gravity acceleration and gravity tensor
+components of a single point mass on a single observation point:
 
 .. jupyter-execute::
 
-    import numpy as np
-    from choclo.prism import gravity_u
+   import choclo
 
-    # Define a single computation point
-    easting, northing, upward = 0.0, 0.0, 10.0
+   # Define a single point mass located 10 meters below the zero height
+   easting_m, northing_m, upward_m = 0., 0., -10.
+   mass = 1e4  # mass of the source in kg
 
-    # Define the boundaries of the prism as a 1d-array
-    prism = np.array([-10.0, 10.0, -7.0, 7.0, -15.0, -5.0])
+   # Define coordinates of an observation point 2 meters above the zero height
+   easting, northing, upward = 0., 0., 2.
 
-    # And its density
-    density = 400.0
+   # Compute the upward compont of the gravity acceleration the point mass
+   # generates on this observation point (in SI units)
+   g_u = choclo.point.gravity_u(
+      easting, northing, upward, easting_m, northing_m, upward_m, mass
+   )
+   print(f"g_u: {g_u:.2e} m s^(-2)")
 
-    # Compute the upward component of the grav. acceleration
-    g_u = gravity_u(easting, northing, upward, prism, density)
-    g_u
+   # Compute gravity tensor components (in SI units)
+   g_eu = choclo.point.gravity_eu(
+      easting, northing, upward, easting_m, northing_m, upward_m, mass
+   )
+   g_uu = choclo.point.gravity_uu(
+      easting, northing, upward, easting_m, northing_m, upward_m, mass
+   )
+   print(f"g_eu: {g_eu:.2e} s^(-2)")
+   print(f"g_uu: {g_uu:.2e} s^(-2)")
 
-But this case is very simple: we usually deal with multiple sources and
-multiple computation points.
 
-Multiple sources and computation points
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-In case we have a collection of prisms with certain densities:
-
-.. jupyter-execute::
-
-   prisms = np.array([
-       [-10.0, 0.0, -7.0, 0.0, -15.0, -10.0],
-       [-10.0, 0.0, 0.0, 7.0, -25.0, -15.0],
-       [0.0, 10.0, -7.0, 0.0, -20.0, -13.0],
-       [0.0, 10.0, 0.0, 7.0, -12.0, -8.0],
-   ])
-   densities = np.array([200.0, 300.0, -100.0, 400.0])
-
-And a set of observation points:
+We can do something similar for a rectangular prism:
 
 .. jupyter-execute::
 
-   easting = np.linspace(-5.0, 5.0, 21)
-   northing = np.linspace(-4.0, 4.0, 21)
-   easting, northing = np.meshgrid(easting, northing)
-   upward = 10 * np.ones_like(easting)
+   import numpy as np
 
-   coordinates = (easting.ravel(), northing.ravel(), upward.ravel())
+   # Define a single rectangular prism through its boundaries
+   west, east, south, north, bottom, top = -1., 5., -4., 4., -20., -10.
+   prism = np.array([west, east, south, north, bottom, top])
+   density = 2900  # density of the prism in kg m^(-3)
 
-And we want to compute the gravitational acceleration that those prisms
-generate on each observation point, we need to write some kind of loop that
-computes the effect of each prism on each observation point and adds it to
-a running result.
+   # Define coordinates of an observation point
+   easting, northing, upward = 1., 3., -1.
 
-A possible solution would be to use Python for loops:
+   # Compute the upward compont of the gravity acceleration the prism
+   # generates on this observation point (in SI units)
+   g_u = choclo.prism.gravity_u(easting, northing, upward, prism, density)
+   print(f"g_u: {g_u:.2e} m s^(-2)")
 
-.. jupyter-execute::
+   # Compute gravity tensor components (in SI units)
+   g_nu = choclo.prism.gravity_nu(easting, northing, upward, prism, density)
+   g_ee = choclo.prism.gravity_ee(easting, northing, upward, prism, density)
+   print(f"g_nu: {g_nu:.2e} s^(-2)")
+   print(f"g_ee: {g_ee:.2e} s^(-2)")
 
-   def gravity_upward_slow(coordinates, prisms, densities):
-       """
-       Compute the upward component of the acceleration of a set of prisms
-       """
-       # Unpack coordinates of the observation points
-       easting, northing, upward = coordinates[:]
-       # Initialize a result array full of zeros
-       result = np.zeros_like(easting, dtype=np.float64)
-       # Compute the upward component that every prism generate on each
-       # observation point
-       for i in range(len(easting)):
-           for j in range(prisms.shape[0]):
-               result[i] += gravity_u(
-                   easting[i], northing[i], upward[i], prisms[j, :], densities[j]
-               )
-       return result
 
-We use this function to compute the field on every point of the grid:
+Magnetic forward modelling
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. jupyter-execute::
+Choclo also offers functions for computing the magnetic field of dipoles and
+rectangular prisms. We can choose to compute the three components at once (using
+functions like :func:`choclo.dipole.magnetic_field` and
+:func:`choclo.prism.magnetic_field`), or one component at a time (see
+:func:`choclo.dipole.magnetic_e` and :func:`choclo.prism.magnetic_u` for
+example).
 
-   g_u = gravity_upward_slow(coordinates, prisms, densities)
-
-And plot the results:
+For example, we can compute the three magnetic field components of a dipole on
+a single observation point:
 
 .. jupyter-execute::
 
-   import matplotlib.pyplot as plt
+   # Define the location of a dipole
+   easting_d, northing_d, upward_d = -4., 2., -1.
 
-   plt.pcolormesh(easting, northing, g_u.reshape(easting.shape), shading='auto')
-   plt.gca().set_aspect("equal")
-   plt.colorbar()
-   plt.show()
+   # Define the magnetic moment vector of the dipole (in A m^2)
+   mag_moment_e, mag_moment_n, mag_moment_u = 1., 1., -2.
+   magnetic_moment = np.array([mag_moment_e, mag_moment_n, mag_moment_u])
 
-"For loops" are known to be slow, and in case we are working with very large
-models and a large number of computation points these calculations could take
-too long. So this solution is not recommended.
+   # Define coordinates of an observation point
+   easting, northing, upward = -2., 2., 2.
+
+   # Compute the magnetic field of the dipole on the observation point (in T)
+   b_e, b_n, b_u = choclo.dipole.magnetic_field(
+      easting, northing, upward, easting_d, northing_d, upward_d, magnetic_moment
+   )
+   print(f"b_e: {b_e:.2e} T")
+   print(f"b_n: {b_n:.2e} T")
+   print(f"b_u: {b_u:.2e} T")
+
+
+Or the upward component of the magnetic field generated by a prism:
+
+.. jupyter-execute::
+
+   # Define a rectangular prism
+   west, east, south, north, bottom, top = -1., 5., -4., 4., -20., -10.
+   prism = np.array([west, east, south, north, bottom, top])
+
+   # Define its magnetization vector (in A m^(-1))
+   m_e, m_n, m_u = 0.5, -1.5, -1.3
+   magnetization = np.array([m_e, m_n, m_u])
+
+   # Define coordinates of an observation point
+   easting, northing, upward = 3., 0., -1.
+
+   # Compute the upward component of the magnetic field of the prism (in T)
+   b_u = choclo.prism.magnetic_u(easting, northing, upward, prism, magnetization)
+   print(f"b_u: {b_u:.2e} T")
 
 .. important::
 
-   Using Python "for loops" to run Choclo's functions is not advisable!
-
-
-We can write a much faster and efficient solution relying on :mod:`numba`.
-Since every function in Choclo is being JIT compiled, we can safely include
-calls to these functions inside other JIT compiled functions. So we can write
-an alternative function by adding a ``@numba.jit`` decorator:
-
-
-.. jupyter-execute::
-
-   import numba
-
-   @numba.jit(nopython=True)
-   def gravity_upward_jit(coordinates, prisms, densities):
-       """
-       Compute the upward component of the acceleration of a set of prisms
-       """
-       # Unpack coordinates of the observation points
-       easting, northing, upward = coordinates[:]
-       # Initialize a result array full of zeros
-       result = np.zeros_like(easting, dtype=np.float64)
-       # Compute the upward component that every prism generate on each
-       # observation point
-       for i in range(len(easting)):
-           for j in range(prisms.shape[0]):
-               result[i] += gravity_u(
-                   easting[i], northing[i], upward[i], prisms[j, :], densities[j]
-               )
-       return result
-
-   g_u = gravity_upward_jit(coordinates, prisms, densities)
-
-   plt.pcolormesh(easting, northing, g_u.reshape(easting.shape), shading='auto')
-   plt.gca().set_aspect("equal")
-   plt.colorbar()
-   plt.show()
-
-Let's benchmark these two functions to see how much faster the decorated
-function runs:
-
-.. jupyter-execute::
-
-   %timeit gravity_upward_slow(coordinates, prisms, densities)
-
-.. jupyter-execute::
-
-   %timeit gravity_upward_jit(coordinates, prisms, densities)
-
-From these numbers we can see that we have significantly reduced the
-computation time by several factors by just decorating our function.
-
-.. note::
-
-   The benchmarked times may vary if you run them in your system.
+   Computing the three components independently is less efficient than
+   computing them all at once using the :func:`choclo.dipole.magnetic_field` or
+   :func:`choclo.prism.magnetic_field` functions.
 
 .. seealso::
 
-   Check `How to measure the performance of Numba?
-   <https://numba.readthedocs.io/en/stable/user/5minguide.html#how-to-measure-the-performance-of-numba>`__
-   to learn more about how to properly benchmark jitted functions.
-
-
-Parallelizing our runs
-~~~~~~~~~~~~~~~~~~~~~~
-
-We have already shown how we can reduce the computation times of our forward
-modelling by decorating our functions with ``@numba.jit(nopython=True)``. But
-this is just the first step: all the computations were being run in *serial* in
-a single CPU. We can harness the full power of our modern multiprocessors CPUs
-by parallelizing our runs. To do so we need to use the :func:`numba.prange`
-instead of the regular Python ``range`` function and slightly change the
-decorator of our function by adding a ``parallel=True`` argument:
-
-.. jupyter-execute::
-
-   @numba.jit(nopython=True, parallel=True)
-   def gravity_upward_parallel(coordinates, prisms, densities):
-       """
-       Compute the upward component of the acceleration of a set of prisms
-       """
-       # Unpack coordinates of the observation points
-       easting, northing, upward = coordinates[:]
-       # Initialize a result array full of zeros
-       result = np.zeros_like(easting, dtype=np.float64)
-       # Compute the upward component that every prism generate on each
-       # observation point
-       for i in numba.prange(len(easting)):
-           for j in range(prisms.shape[0]):
-               result[i] += gravity_u(
-                   easting[i], northing[i], upward[i], prisms[j, :], densities[j]
-               )
-       return result
-
-   g_u = gravity_upward_parallel(coordinates, prisms, densities)
-
-   plt.pcolormesh(easting, northing, g_u.reshape(easting.shape), shading='auto')
-   plt.gca().set_aspect("equal")
-   plt.colorbar()
-   plt.show()
-
-With :func:`numba.prange` we can specify which loop we want to run in parallel.
-Since we are updating the values of ``results`` on each iteration, it's
-advisable to parallelize the loop over the observation points.
-By setting ``parallel=True`` in the decorator we are telling Numba to
-parallelize this function, otherwise Numba will reinterpret the
-``numba.prange`` function as a regular ``range`` and run this loop in serial.
-
-.. note::
-
-   In some applications it's desirable that our forward models are run in
-   serial. For example, if they are part of larger problem that gets
-   parallelized at a higher level. The ``parallel`` parameter in the
-   ``numba.jit`` decorator allows us to change this behaviour at will without
-   having to modify the function code.
-
-Let's benchmark this function against the non-parallelized
-``gravity_upward_jit``:
-
-.. jupyter-execute::
-
-   %timeit gravity_upward_jit(coordinates, prisms, densities)
-
-.. jupyter-execute::
-
-   %timeit gravity_upward_parallel(coordinates, prisms, densities)
-
-By distributing the load between multiple processors we were capable of
-lowering the computation time by a few more factors.
+   :ref:`howtouse` provides detailed instructions on how to use Choclo to
+   efficiently compute gravity and magnetic fields of multiple sources on
+   multiple observation points.
 
 ----
 

--- a/doc/user_guide/how-to-use.rst
+++ b/doc/user_guide/how-to-use.rst
@@ -1,0 +1,249 @@
+.. _howtouse:
+
+How to use Choclo
+=================
+
+The simplest case
+-----------------
+
+Using Choclo is very simple, but it requires some work from our side. Let's say
+we need to compute the upward component of the gravitational acceleration that
+a single rectangular prism produces on a single computation point. To do so we
+can just call the :func:`choclo.prism.gravity_u` function:
+
+.. jupyter-execute::
+
+    import numpy as np
+    from choclo.prism import gravity_u
+
+    # Define a single computation point
+    easting, northing, upward = 0.0, 0.0, 10.0
+
+    # Define the boundaries of the prism as a 1d-array
+    prism = np.array([-10.0, 10.0, -7.0, 7.0, -15.0, -5.0])
+
+    # And its density
+    density = 400.0
+
+    # Compute the upward component of the grav. acceleration
+    g_u = gravity_u(easting, northing, upward, prism, density)
+    g_u
+
+But this case is very simple: we usually deal with multiple sources and
+multiple computation points.
+
+Multiple sources and computation points
+---------------------------------------
+
+In case we have a collection of prisms with certain densities:
+
+.. jupyter-execute::
+
+   prisms = np.array([
+       [-10.0, 0.0, -7.0, 0.0, -15.0, -10.0],
+       [-10.0, 0.0, 0.0, 7.0, -25.0, -15.0],
+       [0.0, 10.0, -7.0, 0.0, -20.0, -13.0],
+       [0.0, 10.0, 0.0, 7.0, -12.0, -8.0],
+   ])
+   densities = np.array([200.0, 300.0, -100.0, 400.0])
+
+And a set of observation points:
+
+.. jupyter-execute::
+
+   easting = np.linspace(-5.0, 5.0, 21)
+   northing = np.linspace(-4.0, 4.0, 21)
+   easting, northing = np.meshgrid(easting, northing)
+   upward = 10 * np.ones_like(easting)
+
+   coordinates = (easting.ravel(), northing.ravel(), upward.ravel())
+
+And we want to compute the gravitational acceleration that those prisms
+generate on each observation point, we need to write some kind of loop that
+computes the effect of each prism on each observation point and adds it to
+a running result.
+
+A possible solution would be to use Python *for loops*:
+
+.. jupyter-execute::
+
+   def gravity_upward_slow(coordinates, prisms, densities):
+       """
+       Compute the upward component of the acceleration of a set of prisms
+       """
+       # Unpack coordinates of the observation points
+       easting, northing, upward = coordinates[:]
+       # Initialize a result array full of zeros
+       result = np.zeros_like(easting, dtype=np.float64)
+       # Compute the upward component that every prism generate on each
+       # observation point
+       for i in range(len(easting)):
+           for j in range(prisms.shape[0]):
+               result[i] += gravity_u(
+                   easting[i], northing[i], upward[i], prisms[j, :], densities[j]
+               )
+       return result
+
+We use this function to compute the field on every point of the grid:
+
+.. jupyter-execute::
+
+   g_u = gravity_upward_slow(coordinates, prisms, densities)
+
+And plot the results:
+
+.. jupyter-execute::
+
+   import matplotlib.pyplot as plt
+
+   plt.pcolormesh(easting, northing, g_u.reshape(easting.shape), shading='auto')
+   plt.gca().set_aspect("equal")
+   plt.colorbar()
+   plt.show()
+
+*For loops* are known to be slow, and in case we are working with very large
+models and a large number of computation points these calculations could take
+too long. So this solution is not recommended.
+
+.. important::
+
+   Using Python *for loops* to run Choclo's functions is not advisable!
+
+
+We can write a much faster and efficient solution relying on :mod:`numba`.
+Since every function in Choclo is being JIT compiled, we can safely include
+calls to these functions inside other JIT compiled functions. So we can write
+an alternative function by adding a ``@numba.jit`` decorator:
+
+
+.. jupyter-execute::
+
+   import numba
+
+   @numba.jit(nopython=True)
+   def gravity_upward_jit(coordinates, prisms, densities):
+       """
+       Compute the upward component of the acceleration of a set of prisms
+       """
+       # Unpack coordinates of the observation points
+       easting, northing, upward = coordinates[:]
+       # Initialize a result array full of zeros
+       result = np.zeros_like(easting, dtype=np.float64)
+       # Compute the upward component that every prism generate on each
+       # observation point
+       for i in range(len(easting)):
+           for j in range(prisms.shape[0]):
+               result[i] += gravity_u(
+                   easting[i], northing[i], upward[i], prisms[j, :], densities[j]
+               )
+       return result
+
+   g_u = gravity_upward_jit(coordinates, prisms, densities)
+
+   plt.pcolormesh(easting, northing, g_u.reshape(easting.shape), shading='auto')
+   plt.gca().set_aspect("equal")
+   plt.colorbar()
+   plt.show()
+
+Let's benchmark these two functions to see how much faster the decorated
+function runs:
+
+.. jupyter-execute::
+
+   %timeit gravity_upward_slow(coordinates, prisms, densities)
+
+.. jupyter-execute::
+
+   %timeit gravity_upward_jit(coordinates, prisms, densities)
+
+From these numbers we can see that we have significantly reduced the
+computation time by several factors by just decorating our function.
+
+.. note::
+
+   The benchmarked times may vary if you run them in your system.
+
+.. seealso::
+
+   Check `How to measure the performance of Numba?
+   <https://numba.readthedocs.io/en/stable/user/5minguide.html#how-to-measure-the-performance-of-numba>`__
+   to learn more about how to properly benchmark jitted functions.
+
+
+Parallelizing our runs
+----------------------
+
+We have already shown how we can reduce the computation times of our forward
+modelling by decorating our functions with ``@numba.jit(nopython=True)``. But
+this is just the first step: all the computations were being run in *serial* in
+a single CPU. We can harness the full power of our modern multiprocessors CPUs
+by parallelizing our runs. To do so we need to use the :func:`numba.prange`
+instead of the regular Python ``range`` function and slightly change the
+decorator of our function by adding a ``parallel=True`` argument:
+
+.. jupyter-execute::
+
+   @numba.jit(nopython=True, parallel=True)
+   def gravity_upward_parallel(coordinates, prisms, densities):
+       """
+       Compute the upward component of the acceleration of a set of prisms
+       """
+       # Unpack coordinates of the observation points
+       easting, northing, upward = coordinates[:]
+       # Initialize a result array full of zeros
+       result = np.zeros_like(easting, dtype=np.float64)
+       # Compute the upward component that every prism generate on each
+       # observation point
+       for i in numba.prange(len(easting)):
+           for j in range(prisms.shape[0]):
+               result[i] += gravity_u(
+                   easting[i], northing[i], upward[i], prisms[j, :], densities[j]
+               )
+       return result
+
+   g_u = gravity_upward_parallel(coordinates, prisms, densities)
+
+   plt.pcolormesh(easting, northing, g_u.reshape(easting.shape), shading='auto')
+   plt.gca().set_aspect("equal")
+   plt.colorbar()
+   plt.show()
+
+With :func:`numba.prange` we can specify which loop we want to run in parallel.
+Since we are updating the values of ``results`` on each iteration, it's
+advisable to parallelize the loop over the observation points.
+By setting ``parallel=True`` in the decorator we are telling Numba to
+parallelize this function, otherwise Numba will reinterpret the
+``numba.prange`` function as a regular ``range`` and run this loop in serial.
+
+.. note::
+
+   In some applications it's desirable that our forward models are run in
+   serial. For example, if they are part of larger problem that gets
+   parallelized at a higher level. The ``parallel`` parameter in the
+   ``numba.jit`` decorator allows us to change this behaviour at will without
+   having to modify the function code.
+
+Let's benchmark this function against the non-parallelized
+``gravity_upward_jit``:
+
+.. jupyter-execute::
+
+   %timeit gravity_upward_jit(coordinates, prisms, densities)
+
+.. jupyter-execute::
+
+   %timeit gravity_upward_parallel(coordinates, prisms, densities)
+
+By distributing the load between multiple processors we were capable of
+lowering the computation time by a few more factors.
+
+----
+
+.. grid:: 2
+
+    .. grid-item-card:: :jupyter-download-script:`Download Python script <how-to-use>`
+        :text-align: center
+
+    .. grid-item-card:: :jupyter-download-nb:`Download Jupyter notebook <how-to-use>`
+        :text-align: center
+

--- a/doc/user_guide/jacobian.rst
+++ b/doc/user_guide/jacobian.rst
@@ -157,7 +157,7 @@ a dot product between it and the density vector of the prisms
    :func:`numpy.matmul` function.
 
 We can check that this result is right by comparing it with the output of the
-``gravity_u_parallel`` function we defined in the :ref:`overview`:
+``gravity_u_parallel`` function we defined in the :ref:`howtouse`:
 
 .. jupyter-execute::
    :hide-code:

--- a/env/requirements-docs.txt
+++ b/env/requirements-docs.txt
@@ -3,7 +3,7 @@ sphinx==4.5.*
 sphinx-book-theme==0.3.*
 sphinx-copybutton==0.5.*
 sphinx-design==0.1.*
-jupyter-sphinx=0.3.*
+jupyter-sphinx=0.4.*
 numpy
 numba
 matplotlib


### PR DESCRIPTION
Move "How to use Choclo" to its own user guide page. Bump version of `jupyter-sphinx` in `requirements-docs.txt` so the download links render properly.
