### PR TITLE
Add missing matplotlib to the dev environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: choclo
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - python==3.9
   - pip
@@ -22,6 +21,7 @@ dependencies:
   - sphinx-copybutton==0.5.*
   - sphinx-design==0.1.*
   - jupyter-sphinx==0.4.*
+  - matplotlib
   # Style
   - black
   - pathspec


### PR DESCRIPTION
It was included in the `env/requirements-docs.txt` but not in the `environment.yml`.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->
