### PR TITLE
Take only scalar inputs instead of array inputs 

### DIFF
--- a/choclo/dipole/_forward.py
+++ b/choclo/dipole/_forward.py
@@ -12,7 +12,15 @@ from ..constants import VACUUM_MAGNETIC_PERMEABILITY
 
 @jit(nopython=True)
 def magnetic_field(
-    easting_p, northing_p, upward_p, easting_q, northing_q, upward_q, magnetic_moment
+    easting_p,
+    northing_p,
+    upward_p,
+    easting_q,
+    northing_q,
+    upward_q,
+    magnetic_moment_east,
+    magnetic_moment_north,
+    magnetic_moment_up,
 ):
     r"""
     Magnetic field due to a dipole
@@ -89,24 +97,34 @@ def magnetic_field(
     r_u = upward_p - upward_q
     distance = np.sqrt(r_e**2 + r_n**2 + r_u**2)
     dotproduct = (
-        magnetic_moment[0] * r_e + magnetic_moment[1] * r_n + magnetic_moment[2] * r_u
+        magnetic_moment_east * r_e
+        + magnetic_moment_north * r_n
+        + magnetic_moment_up * r_u
     )
     c_m = VACUUM_MAGNETIC_PERMEABILITY / 4 / np.pi
     b_e = c_m * (
-        3 * dotproduct * r_e / distance**5 - magnetic_moment[0] / distance**3
+        3 * dotproduct * r_e / distance**5 - magnetic_moment_east / distance**3
     )
     b_n = c_m * (
-        3 * dotproduct * r_n / distance**5 - magnetic_moment[1] / distance**3
+        3 * dotproduct * r_n / distance**5 - magnetic_moment_north / distance**3
     )
     b_u = c_m * (
-        3 * dotproduct * r_u / distance**5 - magnetic_moment[2] / distance**3
+        3 * dotproduct * r_u / distance**5 - magnetic_moment_up / distance**3
     )
     return b_e, b_n, b_u
 
 
 @jit(nopython=True)
 def magnetic_e(
-    easting_p, northing_p, upward_p, easting_q, northing_q, upward_q, magnetic_moment
+    easting_p,
+    northing_p,
+    upward_p,
+    easting_q,
+    northing_q,
+    upward_q,
+    magnetic_moment_east,
+    magnetic_moment_north,
+    magnetic_moment_up,
 ):
     r"""
     Easting component of the magnetic field due to a dipole
@@ -174,15 +192,25 @@ def magnetic_e(
     r_u = upward_p - upward_q
     distance = np.sqrt(r_e**2 + r_n**2 + r_u**2)
     dotproduct = (
-        magnetic_moment[0] * r_e + magnetic_moment[1] * r_n + magnetic_moment[2] * r_u
+        magnetic_moment_east * r_e
+        + magnetic_moment_north * r_n
+        + magnetic_moment_up * r_u
     )
-    result = 3 * dotproduct * r_e / distance**5 - magnetic_moment[0] / distance**3
+    result = 3 * dotproduct * r_e / distance**5 - magnetic_moment_east / distance**3
     return VACUUM_MAGNETIC_PERMEABILITY / 4 / np.pi * result
 
 
 @jit(nopython=True)
 def magnetic_n(
-    easting_p, northing_p, upward_p, easting_q, northing_q, upward_q, magnetic_moment
+    easting_p,
+    northing_p,
+    upward_p,
+    easting_q,
+    northing_q,
+    upward_q,
+    magnetic_moment_east,
+    magnetic_moment_north,
+    magnetic_moment_up,
 ):
     r"""
     Northing component of the magnetic field due to a dipole
@@ -250,15 +278,27 @@ def magnetic_n(
     r_u = upward_p - upward_q
     distance = np.sqrt(r_e**2 + r_n**2 + r_u**2)
     dotproduct = (
-        magnetic_moment[0] * r_e + magnetic_moment[1] * r_n + magnetic_moment[2] * r_u
+        magnetic_moment_east * r_e
+        + magnetic_moment_north * r_n
+        + magnetic_moment_up * r_u
     )
-    result = 3 * dotproduct * r_n / distance**5 - magnetic_moment[1] / distance**3
+    result = (
+        3 * dotproduct * r_n / distance**5 - magnetic_moment_north / distance**3
+    )
     return VACUUM_MAGNETIC_PERMEABILITY / 4 / np.pi * result
 
 
 @jit(nopython=True)
 def magnetic_u(
-    easting_p, northing_p, upward_p, easting_q, northing_q, upward_q, magnetic_moment
+    easting_p,
+    northing_p,
+    upward_p,
+    easting_q,
+    northing_q,
+    upward_q,
+    magnetic_moment_east,
+    magnetic_moment_north,
+    magnetic_moment_up,
 ):
     r"""
     Upward component of the magnetic field due to a dipole
@@ -326,7 +366,9 @@ def magnetic_u(
     r_u = upward_p - upward_q
     distance = np.sqrt(r_e**2 + r_n**2 + r_u**2)
     dotproduct = (
-        magnetic_moment[0] * r_e + magnetic_moment[1] * r_n + magnetic_moment[2] * r_u
+        magnetic_moment_east * r_e
+        + magnetic_moment_north * r_n
+        + magnetic_moment_up * r_u
     )
-    result = 3 * dotproduct * r_u / distance**5 - magnetic_moment[2] / distance**3
+    result = 3 * dotproduct * r_u / distance**5 - magnetic_moment_up / distance**3
     return VACUUM_MAGNETIC_PERMEABILITY / 4 / np.pi * result

--- a/choclo/prism/_gravity.py
+++ b/choclo/prism/_gravity.py
@@ -34,7 +34,18 @@ from ._utils import (
 
 
 @jit(nopython=True)
-def gravity_pot(easting, northing, upward, prism, density):
+def gravity_pot(
+    easting,
+    northing,
+    upward,
+    prism_west,
+    prism_east,
+    prism_south,
+    prism_north,
+    prism_bottom,
+    prism_top,
+    density,
+):
     r"""
     Gravitational potential field due to a rectangular prism
 
@@ -146,12 +157,34 @@ def gravity_pot(easting, northing, upward, prism, density):
     return (
         GRAVITATIONAL_CONST
         * density
-        * _evaluate_kernel(easting, northing, upward, prism, kernel_pot)
+        * _evaluate_kernel(
+            easting,
+            northing,
+            upward,
+            prism_west,
+            prism_east,
+            prism_south,
+            prism_north,
+            prism_bottom,
+            prism_top,
+            kernel_pot,
+        )
     )
 
 
 @jit(nopython=True)
-def gravity_e(easting, northing, upward, prism, density):
+def gravity_e(
+    easting,
+    northing,
+    upward,
+    prism_west,
+    prism_east,
+    prism_south,
+    prism_north,
+    prism_bottom,
+    prism_top,
+    density,
+):
     r"""
     Easting component of the gravitational acceleration due to a prism
 
@@ -264,12 +297,34 @@ def gravity_e(easting, northing, upward, prism, density):
     return (
         GRAVITATIONAL_CONST
         * density
-        * _evaluate_kernel(easting, northing, upward, prism, kernel_e)
+        * _evaluate_kernel(
+            easting,
+            northing,
+            upward,
+            prism_west,
+            prism_east,
+            prism_south,
+            prism_north,
+            prism_bottom,
+            prism_top,
+            kernel_e,
+        )
     )
 
 
 @jit(nopython=True)
-def gravity_n(easting, northing, upward, prism, density):
+def gravity_n(
+    easting,
+    northing,
+    upward,
+    prism_west,
+    prism_east,
+    prism_south,
+    prism_north,
+    prism_bottom,
+    prism_top,
+    density,
+):
     r"""
     Northing component of the gravitational acceleration due to a prism
 
@@ -382,12 +437,34 @@ def gravity_n(easting, northing, upward, prism, density):
     return (
         GRAVITATIONAL_CONST
         * density
-        * _evaluate_kernel(easting, northing, upward, prism, kernel_n)
+        * _evaluate_kernel(
+            easting,
+            northing,
+            upward,
+            prism_west,
+            prism_east,
+            prism_south,
+            prism_north,
+            prism_bottom,
+            prism_top,
+            kernel_n,
+        )
     )
 
 
 @jit(nopython=True)
-def gravity_u(easting, northing, upward, prism, density):
+def gravity_u(
+    easting,
+    northing,
+    upward,
+    prism_west,
+    prism_east,
+    prism_south,
+    prism_north,
+    prism_bottom,
+    prism_top,
+    density,
+):
     r"""
     Upward component of the gravitational acceleration due to a prism
 
@@ -506,12 +583,34 @@ def gravity_u(easting, northing, upward, prism, density):
     return (
         GRAVITATIONAL_CONST
         * density
-        * _evaluate_kernel(easting, northing, upward, prism, kernel_u)
+        * _evaluate_kernel(
+            easting,
+            northing,
+            upward,
+            prism_west,
+            prism_east,
+            prism_south,
+            prism_north,
+            prism_bottom,
+            prism_top,
+            kernel_u,
+        )
     )
 
 
 @jit(nopython=True)
-def gravity_ee(easting, northing, upward, prism, density):
+def gravity_ee(
+    easting,
+    northing,
+    upward,
+    prism_west,
+    prism_east,
+    prism_south,
+    prism_north,
+    prism_bottom,
+    prism_top,
+    density,
+):
     r"""
     Easting-easting component of the gravitational tensor due to a prism
 
@@ -611,22 +710,71 @@ def gravity_ee(easting, northing, upward, prism, density):
     # Return nan if the observation point falls on a singular point.
     # For the g_ee this are edges perpendicular to the easting direction
     # (parallel to northing and upward)
-    if (
-        is_point_on_northing_edge(easting, northing, upward, prism)
-        or is_point_on_upward_edge(easting, northing, upward, prism)
-    ):  # fmt: skip
+    if is_point_on_northing_edge(
+        easting,
+        northing,
+        upward,
+        prism_west,
+        prism_east,
+        prism_south,
+        prism_north,
+        prism_bottom,
+        prism_top,
+    ) or is_point_on_upward_edge(
+        easting,
+        northing,
+        upward,
+        prism_west,
+        prism_east,
+        prism_south,
+        prism_north,
+        prism_bottom,
+        prism_top,
+    ):
         return np.nan
     # Evaluate kernel function on each vertex of the prism
-    result = _evaluate_kernel(easting, northing, upward, prism, kernel_ee)
+    result = _evaluate_kernel(
+        easting,
+        northing,
+        upward,
+        prism_west,
+        prism_east,
+        prism_south,
+        prism_north,
+        prism_bottom,
+        prism_top,
+        kernel_ee,
+    )
     # Add 4 pi if computing on the eastern face to return the limit approaching
     # from outside (approaching from the east)
-    if is_point_on_east_face(easting, northing, upward, prism):
+    if is_point_on_east_face(
+        easting,
+        northing,
+        upward,
+        prism_west,
+        prism_east,
+        prism_south,
+        prism_north,
+        prism_bottom,
+        prism_top,
+    ):
         result += 4 * np.pi
     return GRAVITATIONAL_CONST * density * result
 
 
 @jit(nopython=True)
-def gravity_nn(easting, northing, upward, prism, density):
+def gravity_nn(
+    easting,
+    northing,
+    upward,
+    prism_west,
+    prism_east,
+    prism_south,
+    prism_north,
+    prism_bottom,
+    prism_top,
+    density,
+):
     r"""
     Northing-northing component of the gravitational tensor due to a prism
 
@@ -727,21 +875,53 @@ def gravity_nn(easting, northing, upward, prism, density):
     # For the g_nn this are edges perpendicular to the northing direction
     # (parallel to easting and upward)
     if (
-        is_point_on_easting_edge(easting, northing, upward, prism)
-        or is_point_on_upward_edge(easting, northing, upward, prism)
+        is_point_on_easting_edge(easting, northing, upward, prism_west, prism_east, prism_south, prism_north, prism_bottom, prism_top)
+        or is_point_on_upward_edge(easting, northing, upward, prism_west, prism_east, prism_south, prism_north, prism_bottom, prism_top)
     ):  # fmt: skip
         return np.nan
     # Evaluate kernel function on each vertex of the prism
-    result = _evaluate_kernel(easting, northing, upward, prism, kernel_nn)
+    result = _evaluate_kernel(
+        easting,
+        northing,
+        upward,
+        prism_west,
+        prism_east,
+        prism_south,
+        prism_north,
+        prism_bottom,
+        prism_top,
+        kernel_nn,
+    )
     # Add 4 pi if computing on the northern face to return the limit
     # approaching from outside (approaching from the north)
-    if is_point_on_north_face(easting, northing, upward, prism):
+    if is_point_on_north_face(
+        easting,
+        northing,
+        upward,
+        prism_west,
+        prism_east,
+        prism_south,
+        prism_north,
+        prism_bottom,
+        prism_top,
+    ):
         result += 4 * np.pi
     return GRAVITATIONAL_CONST * density * result
 
 
 @jit(nopython=True)
-def gravity_uu(easting, northing, upward, prism, density):
+def gravity_uu(
+    easting,
+    northing,
+    upward,
+    prism_west,
+    prism_east,
+    prism_south,
+    prism_north,
+    prism_bottom,
+    prism_top,
+    density,
+):
     r"""
     Upward-upward component of the gravitational tensor due to a prism
 
@@ -842,21 +1022,53 @@ def gravity_uu(easting, northing, upward, prism, density):
     # For the g_uu this are edges perpendicular to the upward direction
     # (parallel to easting and northing)
     if (
-        is_point_on_easting_edge(easting, northing, upward, prism)
-        or is_point_on_northing_edge(easting, northing, upward, prism)
+        is_point_on_easting_edge(easting, northing, upward, prism_west, prism_east, prism_south, prism_north, prism_bottom, prism_top)
+        or is_point_on_northing_edge(easting, northing, upward, prism_west, prism_east, prism_south, prism_north, prism_bottom, prism_top)
     ):  # fmt: skip
         return np.nan
     # Evaluate kernel function on each vertex of the prism
-    result = _evaluate_kernel(easting, northing, upward, prism, kernel_uu)
+    result = _evaluate_kernel(
+        easting,
+        northing,
+        upward,
+        prism_west,
+        prism_east,
+        prism_south,
+        prism_north,
+        prism_bottom,
+        prism_top,
+        kernel_uu,
+    )
     # Add 4 pi if computing on the top face to return the limit approaching
     # from outside (approaching from the top)
-    if is_point_on_top_face(easting, northing, upward, prism):
+    if is_point_on_top_face(
+        easting,
+        northing,
+        upward,
+        prism_west,
+        prism_east,
+        prism_south,
+        prism_north,
+        prism_bottom,
+        prism_top,
+    ):
         result += 4 * np.pi
     return GRAVITATIONAL_CONST * density * result
 
 
 @jit(nopython=True)
-def gravity_en(easting, northing, upward, prism, density):
+def gravity_en(
+    easting,
+    northing,
+    upward,
+    prism_west,
+    prism_east,
+    prism_south,
+    prism_north,
+    prism_bottom,
+    prism_top,
+    density,
+):
     r"""
     Easting-northing component of the gravitational tensor due to a prism
 
@@ -954,17 +1166,49 @@ def gravity_en(easting, northing, upward, prism, density):
     """
     # Return nan if the observation point falls on a singular point.
     # For g_en this are edges parallel to to the upward direction
-    if is_point_on_upward_edge(easting, northing, upward, prism):
+    if is_point_on_upward_edge(
+        easting,
+        northing,
+        upward,
+        prism_west,
+        prism_east,
+        prism_south,
+        prism_north,
+        prism_bottom,
+        prism_top,
+    ):
         return np.nan
     return (
         GRAVITATIONAL_CONST
         * density
-        * _evaluate_kernel(easting, northing, upward, prism, kernel_en)
+        * _evaluate_kernel(
+            easting,
+            northing,
+            upward,
+            prism_west,
+            prism_east,
+            prism_south,
+            prism_north,
+            prism_bottom,
+            prism_top,
+            kernel_en,
+        )
     )
 
 
 @jit(nopython=True)
-def gravity_eu(easting, northing, upward, prism, density):
+def gravity_eu(
+    easting,
+    northing,
+    upward,
+    prism_west,
+    prism_east,
+    prism_south,
+    prism_north,
+    prism_bottom,
+    prism_top,
+    density,
+):
     r"""
     Easting-upward component of the gravitational tensor due to a prism
 
@@ -1063,17 +1307,49 @@ def gravity_eu(easting, northing, upward, prism, density):
     """
     # Return nan if the observation point falls on a singular point.
     # For g_eu this are edges parallel to to the northing direction
-    if is_point_on_northing_edge(easting, northing, upward, prism):
+    if is_point_on_northing_edge(
+        easting,
+        northing,
+        upward,
+        prism_west,
+        prism_east,
+        prism_south,
+        prism_north,
+        prism_bottom,
+        prism_top,
+    ):
         return np.nan
     return (
         GRAVITATIONAL_CONST
         * density
-        * _evaluate_kernel(easting, northing, upward, prism, kernel_eu)
+        * _evaluate_kernel(
+            easting,
+            northing,
+            upward,
+            prism_west,
+            prism_east,
+            prism_south,
+            prism_north,
+            prism_bottom,
+            prism_top,
+            kernel_eu,
+        )
     )
 
 
 @jit(nopython=True)
-def gravity_nu(easting, northing, upward, prism, density):
+def gravity_nu(
+    easting,
+    northing,
+    upward,
+    prism_west,
+    prism_east,
+    prism_south,
+    prism_north,
+    prism_bottom,
+    prism_top,
+    density,
+):
     r"""
     Northing-upward component of the gravitational tensor due to a prism
 
@@ -1172,17 +1448,49 @@ def gravity_nu(easting, northing, upward, prism, density):
     """
     # Return nan if the observation point falls on a singular point.
     # For g_nu this are edges parallel to to the easting direction
-    if is_point_on_easting_edge(easting, northing, upward, prism):
+    if is_point_on_easting_edge(
+        easting,
+        northing,
+        upward,
+        prism_west,
+        prism_east,
+        prism_south,
+        prism_north,
+        prism_bottom,
+        prism_top,
+    ):
         return np.nan
     return (
         GRAVITATIONAL_CONST
         * density
-        * _evaluate_kernel(easting, northing, upward, prism, kernel_nu)
+        * _evaluate_kernel(
+            easting,
+            northing,
+            upward,
+            prism_west,
+            prism_east,
+            prism_south,
+            prism_north,
+            prism_bottom,
+            prism_top,
+            kernel_nu,
+        )
     )
 
 
 @jit(nopython=True)
-def _evaluate_kernel(easting, northing, upward, prism, kernel):
+def _evaluate_kernel(
+    easting,
+    northing,
+    upward,
+    prism_west,
+    prism_east,
+    prism_south,
+    prism_north,
+    prism_bottom,
+    prism_top,
+    kernel,
+):
     r"""
     Evaluate a kernel function on every shifted vertex of a prism
 
@@ -1238,15 +1546,24 @@ def _evaluate_kernel(easting, northing, upward, prism, kernel):
     # Iterate over the vertices of the prism
     for i in range(2):
         # Compute shifted easting coordinate
-        shift_east = prism[1 - i] - easting
+        if i == 0:
+            shift_east = prism_east - easting
+        else:
+            shift_east = prism_west - easting
         shift_east_sq = shift_east**2
         for j in range(2):
             # Compute shifted northing coordinate
-            shift_north = prism[3 - j] - northing
+            if j == 0:
+                shift_north = prism_north - northing
+            else:
+                shift_north = prism_south - northing
             shift_north_sq = shift_north**2
             for k in range(2):
                 # Compute shifted upward coordinate
-                shift_upward = prism[5 - k] - upward
+                if k == 0:
+                    shift_upward = prism_top - upward
+                else:
+                    shift_upward = prism_bottom - upward
                 shift_upward_sq = shift_upward**2
                 # Compute the radius
                 radius = np.sqrt(shift_east_sq + shift_north_sq + shift_upward_sq)

--- a/choclo/prism/_magnetic.py
+++ b/choclo/prism/_magnetic.py
@@ -22,7 +22,20 @@ from ._utils import (
 
 
 @jit(nopython=True)
-def magnetic_field(easting, northing, upward, prism, magnetization):
+def magnetic_field(
+    easting,
+    northing,
+    upward,
+    prism_west,
+    prism_east,
+    prism_south,
+    prism_north,
+    prism_bottom,
+    prism_top,
+    magnetization_east,
+    magnetization_north,
+    magnetization_up,
+):
     r"""
     Magnetic field due to a rectangular prism
 
@@ -197,8 +210,26 @@ def magnetic_field(easting, northing, upward, prism, magnetization):
     :func:`choclo.prism.magnetic_u`
     """
     # Check if observation point falls in a singular point
-    if is_point_on_edge(easting, northing, upward, prism) or is_interior_point(
-        easting, northing, upward, prism
+    if is_point_on_edge(
+        easting,
+        northing,
+        upward,
+        prism_west,
+        prism_east,
+        prism_south,
+        prism_north,
+        prism_bottom,
+        prism_top,
+    ) or is_interior_point(
+        easting,
+        northing,
+        upward,
+        prism_west,
+        prism_east,
+        prism_south,
+        prism_north,
+        prism_bottom,
+        prism_top,
     ):
         return (np.nan, np.nan, np.nan)
     # Initialize magnetic field vector components
@@ -206,15 +237,24 @@ def magnetic_field(easting, northing, upward, prism, magnetization):
     # Iterate over the vertices of the prism
     for i in range(2):
         # Compute shifted easting coordinate
-        shift_east = prism[1 - i] - easting
+        if i == 0:
+            shift_east = prism_east - easting
+        else:
+            shift_east = prism_west - easting
         shift_east_sq = shift_east**2
         for j in range(2):
             # Compute shifted northing coordinate
-            shift_north = prism[3 - j] - northing
+            if j == 0:
+                shift_north = prism_north - northing
+            else:
+                shift_north = prism_south - northing
             shift_north_sq = shift_north**2
             for k in range(2):
                 # Compute shifted upward coordinate
-                shift_upward = prism[5 - k] - upward
+                if k == 0:
+                    shift_upward = prism_top - upward
+                else:
+                    shift_upward = prism_bottom - upward
                 shift_upward_sq = shift_upward**2
                 # Compute the radius
                 radius = np.sqrt(shift_east_sq + shift_north_sq + shift_upward_sq)
@@ -230,32 +270,62 @@ def magnetic_field(easting, northing, upward, prism, magnetization):
                 # Compute the dot product between the kernel tensor and the
                 # magnetization vector of the prism
                 b_e += sign * (
-                    magnetization[0] * k_ee
-                    + magnetization[1] * k_en
-                    + magnetization[2] * k_eu
+                    magnetization_east * k_ee
+                    + magnetization_north * k_en
+                    + magnetization_up * k_eu
                 )
                 b_n += sign * (
-                    magnetization[0] * k_en
-                    + magnetization[1] * k_nn
-                    + magnetization[2] * k_nu
+                    magnetization_east * k_en
+                    + magnetization_north * k_nn
+                    + magnetization_up * k_nu
                 )
                 b_u += sign * (
-                    magnetization[0] * k_eu
-                    + magnetization[1] * k_nu
-                    + magnetization[2] * k_uu
+                    magnetization_east * k_eu
+                    + magnetization_north * k_nu
+                    + magnetization_up * k_uu
                 )
     # Add 4 pi to Be if computing on the eastmost face, to correctly evaluate
     # the limit approaching from outside (approaching from the east)
-    if is_point_on_east_face(easting, northing, upward, prism):
-        b_e += 4 * np.pi * magnetization[0]
+    if is_point_on_east_face(
+        easting,
+        northing,
+        upward,
+        prism_west,
+        prism_east,
+        prism_south,
+        prism_north,
+        prism_bottom,
+        prism_top,
+    ):
+        b_e += 4 * np.pi * magnetization_east
     # Add 4 pi to Bn if computing on the northmost face, to correctly evaluate
     # the limit approaching from outside (approaching from the north)
-    if is_point_on_north_face(easting, northing, upward, prism):
-        b_n += 4 * np.pi * magnetization[1]
+    if is_point_on_north_face(
+        easting,
+        northing,
+        upward,
+        prism_west,
+        prism_east,
+        prism_south,
+        prism_north,
+        prism_bottom,
+        prism_top,
+    ):
+        b_n += 4 * np.pi * magnetization_north
     # Add 4 pi to Bu if computing on the north face, to correctly evaluate the
     # limit approaching from outside (approaching from the top)
-    if is_point_on_top_face(easting, northing, upward, prism):
-        b_u += 4 * np.pi * magnetization[2]
+    if is_point_on_top_face(
+        easting,
+        northing,
+        upward,
+        prism_west,
+        prism_east,
+        prism_south,
+        prism_north,
+        prism_bottom,
+        prism_top,
+    ):
+        b_u += 4 * np.pi * magnetization_up
     c_m = VACUUM_MAGNETIC_PERMEABILITY / 4 / np.pi
     b_e *= c_m
     b_n *= c_m
@@ -264,7 +334,20 @@ def magnetic_field(easting, northing, upward, prism, magnetization):
 
 
 @jit(nopython=True)
-def magnetic_e(easting, northing, upward, prism, magnetization):
+def magnetic_e(
+    easting,
+    northing,
+    upward,
+    prism_west,
+    prism_east,
+    prism_south,
+    prism_north,
+    prism_bottom,
+    prism_top,
+    magnetization_east,
+    magnetization_north,
+    magnetization_up,
+):
     r"""
     Easting component of the magnetic field due to a prism
 
@@ -364,8 +447,26 @@ def magnetic_e(easting, northing, upward, prism, magnetization):
     :func:`choclo.prism.magnetic_u`
     """
     # Check if observation point falls in a singular point
-    if is_point_on_edge(easting, northing, upward, prism) or is_interior_point(
-        easting, northing, upward, prism
+    if is_point_on_edge(
+        easting,
+        northing,
+        upward,
+        prism_west,
+        prism_east,
+        prism_south,
+        prism_north,
+        prism_bottom,
+        prism_top,
+    ) or is_interior_point(
+        easting,
+        northing,
+        upward,
+        prism_west,
+        prism_east,
+        prism_south,
+        prism_north,
+        prism_bottom,
+        prism_top,
     ):
         return np.nan
     # Initialize magnetic field vector component
@@ -373,15 +474,24 @@ def magnetic_e(easting, northing, upward, prism, magnetization):
     # Iterate over the vertices of the prism
     for i in range(2):
         # Compute shifted easting coordinate
-        shift_east = prism[1 - i] - easting
+        if i == 0:
+            shift_east = prism_east - easting
+        else:
+            shift_east = prism_west - easting
         shift_east_sq = shift_east**2
         for j in range(2):
             # Compute shifted northing coordinate
-            shift_north = prism[3 - j] - northing
+            if j == 0:
+                shift_north = prism_north - northing
+            else:
+                shift_north = prism_south - northing
             shift_north_sq = shift_north**2
             for k in range(2):
                 # Compute shifted upward coordinate
-                shift_upward = prism[5 - k] - upward
+                if k == 0:
+                    shift_upward = prism_top - upward
+                else:
+                    shift_upward = prism_bottom - upward
                 shift_upward_sq = shift_upward**2
                 # Compute the radius
                 radius = np.sqrt(shift_east_sq + shift_north_sq + shift_upward_sq)
@@ -392,19 +502,42 @@ def magnetic_e(easting, northing, upward, prism, magnetization):
                 # Compute b_e using the dot product between the kernel tensor
                 # and the magnetization vector of the prism
                 b_e += (-1) ** (i + j + k) * (
-                    magnetization[0] * k_ee
-                    + magnetization[1] * k_en
-                    + magnetization[2] * k_eu
+                    magnetization_east * k_ee
+                    + magnetization_north * k_en
+                    + magnetization_up * k_eu
                 )
     # Add 4 pi to Be if computing on the eastmost face, to correctly evaluate
     # the limit approaching from outside (approaching from the east)
-    if is_point_on_east_face(easting, northing, upward, prism):
-        b_e += 4 * np.pi * magnetization[0]
+    if is_point_on_east_face(
+        easting,
+        northing,
+        upward,
+        prism_west,
+        prism_east,
+        prism_south,
+        prism_north,
+        prism_bottom,
+        prism_top,
+    ):
+        b_e += 4 * np.pi * magnetization_east
     return VACUUM_MAGNETIC_PERMEABILITY / 4 / np.pi * b_e
 
 
 @jit(nopython=True)
-def magnetic_n(easting, northing, upward, prism, magnetization):
+def magnetic_n(
+    easting,
+    northing,
+    upward,
+    prism_west,
+    prism_east,
+    prism_south,
+    prism_north,
+    prism_bottom,
+    prism_top,
+    magnetization_east,
+    magnetization_north,
+    magnetization_up,
+):
     r"""
     Northing component of the magnetic field due to a prism
 
@@ -504,8 +637,26 @@ def magnetic_n(easting, northing, upward, prism, magnetization):
     :func:`choclo.prism.magnetic_u`
     """
     # Check if observation point falls in a singular point
-    if is_point_on_edge(easting, northing, upward, prism) or is_interior_point(
-        easting, northing, upward, prism
+    if is_point_on_edge(
+        easting,
+        northing,
+        upward,
+        prism_west,
+        prism_east,
+        prism_south,
+        prism_north,
+        prism_bottom,
+        prism_top,
+    ) or is_interior_point(
+        easting,
+        northing,
+        upward,
+        prism_west,
+        prism_east,
+        prism_south,
+        prism_north,
+        prism_bottom,
+        prism_top,
     ):
         return np.nan
     # Initialize magnetic field vector component
@@ -513,15 +664,24 @@ def magnetic_n(easting, northing, upward, prism, magnetization):
     # Iterate over the vertices of the prism
     for i in range(2):
         # Compute shifted easting coordinate
-        shift_east = prism[1 - i] - easting
+        if i == 0:
+            shift_east = prism_east - easting
+        else:
+            shift_east = prism_west - easting
         shift_east_sq = shift_east**2
         for j in range(2):
             # Compute shifted northing coordinate
-            shift_north = prism[3 - j] - northing
+            if j == 0:
+                shift_north = prism_north - northing
+            else:
+                shift_north = prism_south - northing
             shift_north_sq = shift_north**2
             for k in range(2):
                 # Compute shifted upward coordinate
-                shift_upward = prism[5 - k] - upward
+                if k == 0:
+                    shift_upward = prism_top - upward
+                else:
+                    shift_upward = prism_bottom - upward
                 shift_upward_sq = shift_upward**2
                 # Compute the radius
                 radius = np.sqrt(shift_east_sq + shift_north_sq + shift_upward_sq)
@@ -532,19 +692,42 @@ def magnetic_n(easting, northing, upward, prism, magnetization):
                 # Compute b_n using the dot product between the kernel tensor
                 # and the magnetization vector of the prism
                 b_n += (-1) ** (i + j + k) * (
-                    magnetization[0] * k_en
-                    + magnetization[1] * k_nn
-                    + magnetization[2] * k_nu
+                    magnetization_east * k_en
+                    + magnetization_north * k_nn
+                    + magnetization_up * k_nu
                 )
     # Add 4 pi to Bn if computing on the northmost face, to correctly evaluate
     # the limit approaching from outside (approaching from the north)
-    if is_point_on_north_face(easting, northing, upward, prism):
-        b_n += 4 * np.pi * magnetization[1]
+    if is_point_on_north_face(
+        easting,
+        northing,
+        upward,
+        prism_west,
+        prism_east,
+        prism_south,
+        prism_north,
+        prism_bottom,
+        prism_top,
+    ):
+        b_n += 4 * np.pi * magnetization_north
     return VACUUM_MAGNETIC_PERMEABILITY / 4 / np.pi * b_n
 
 
 @jit(nopython=True)
-def magnetic_u(easting, northing, upward, prism, magnetization):
+def magnetic_u(
+    easting,
+    northing,
+    upward,
+    prism_west,
+    prism_east,
+    prism_south,
+    prism_north,
+    prism_bottom,
+    prism_top,
+    magnetization_east,
+    magnetization_north,
+    magnetization_up,
+):
     r"""
     Upward component of the magnetic field due to a prism
 
@@ -644,8 +827,26 @@ def magnetic_u(easting, northing, upward, prism, magnetization):
     :func:`choclo.prism.magnetic_n`
     """
     # Check if observation point falls in a singular point
-    if is_point_on_edge(easting, northing, upward, prism) or is_interior_point(
-        easting, northing, upward, prism
+    if is_point_on_edge(
+        easting,
+        northing,
+        upward,
+        prism_west,
+        prism_east,
+        prism_south,
+        prism_north,
+        prism_bottom,
+        prism_top,
+    ) or is_interior_point(
+        easting,
+        northing,
+        upward,
+        prism_west,
+        prism_east,
+        prism_south,
+        prism_north,
+        prism_bottom,
+        prism_top,
     ):
         return np.nan
     # Initialize magnetic field vector component
@@ -653,15 +854,24 @@ def magnetic_u(easting, northing, upward, prism, magnetization):
     # Iterate over the vertices of the prism
     for i in range(2):
         # Compute shifted easting coordinate
-        shift_east = prism[1 - i] - easting
+        if i == 0:
+            shift_east = prism_east - easting
+        else:
+            shift_east = prism_west - easting
         shift_east_sq = shift_east**2
         for j in range(2):
             # Compute shifted northing coordinate
-            shift_north = prism[3 - j] - northing
+            if j == 0:
+                shift_north = prism_north - northing
+            else:
+                shift_north = prism_south - northing
             shift_north_sq = shift_north**2
             for k in range(2):
                 # Compute shifted upward coordinate
-                shift_upward = prism[5 - k] - upward
+                if k == 0:
+                    shift_upward = prism_top - upward
+                else:
+                    shift_upward = prism_bottom - upward
                 shift_upward_sq = shift_upward**2
                 # Compute the radius
                 radius = np.sqrt(shift_east_sq + shift_north_sq + shift_upward_sq)
@@ -672,12 +882,22 @@ def magnetic_u(easting, northing, upward, prism, magnetization):
                 # Compute b_n using the dot product between the kernel tensor
                 # and the magnetization vector of the prism
                 b_u += (-1) ** (i + j + k) * (
-                    magnetization[0] * k_eu
-                    + magnetization[1] * k_nu
-                    + magnetization[2] * k_uu
+                    magnetization_east * k_eu
+                    + magnetization_north * k_nu
+                    + magnetization_up * k_uu
                 )
     # Add 4 pi to Bu if computing on the north face, to correctly evaluate the
     # limit approaching from outside (approaching from the top)
-    if is_point_on_top_face(easting, northing, upward, prism):
-        b_u += 4 * np.pi * magnetization[2]
+    if is_point_on_top_face(
+        easting,
+        northing,
+        upward,
+        prism_west,
+        prism_east,
+        prism_south,
+        prism_north,
+        prism_bottom,
+        prism_top,
+    ):
+        b_u += 4 * np.pi * magnetization_up
     return VACUUM_MAGNETIC_PERMEABILITY / 4 / np.pi * b_u

--- a/choclo/prism/_utils.py
+++ b/choclo/prism/_utils.py
@@ -11,7 +11,17 @@ from numba import jit
 
 
 @jit(nopython=True)
-def is_interior_point(easting, northing, upward, prism):
+def is_interior_point(
+    easting,
+    northing,
+    upward,
+    prism_west,
+    prism_east,
+    prism_south,
+    prism_north,
+    prism_bottom,
+    prism_top,
+):
     """
     Check if observation point falls inside the prism
 
@@ -39,14 +49,24 @@ def is_interior_point(easting, northing, upward, prism):
         Return True if the observation point falls inside the prism, not
         including vertices, edges or faces. Return False if otherwise.
     """
-    in_easting = prism[0] < easting < prism[1]
-    in_northing = prism[2] < northing < prism[3]
-    in_upward = prism[4] < upward < prism[5]
+    in_easting = prism_west < easting < prism_east
+    in_northing = prism_south < northing < prism_north
+    in_upward = prism_bottom < upward < prism_top
     return in_easting and in_northing and in_upward
 
 
 @jit(nopython=True)
-def is_point_on_edge(easting, northing, upward, prism):
+def is_point_on_edge(
+    easting,
+    northing,
+    upward,
+    prism_west,
+    prism_east,
+    prism_south,
+    prism_north,
+    prism_bottom,
+    prism_top,
+):
     """
     Check if observation point falls on any edge of the prism
 
@@ -75,15 +95,55 @@ def is_point_on_edge(easting, northing, upward, prism):
         edges. Return False if otherwise.
     """
     result = (
-        is_point_on_easting_edge(easting, northing, upward, prism)
-        or is_point_on_northing_edge(easting, northing, upward, prism)
-        or is_point_on_upward_edge(easting, northing, upward, prism)
+        is_point_on_easting_edge(
+            easting,
+            northing,
+            upward,
+            prism_west,
+            prism_east,
+            prism_south,
+            prism_north,
+            prism_bottom,
+            prism_top,
+        )
+        or is_point_on_northing_edge(
+            easting,
+            northing,
+            upward,
+            prism_west,
+            prism_east,
+            prism_south,
+            prism_north,
+            prism_bottom,
+            prism_top,
+        )
+        or is_point_on_upward_edge(
+            easting,
+            northing,
+            upward,
+            prism_west,
+            prism_east,
+            prism_south,
+            prism_north,
+            prism_bottom,
+            prism_top,
+        )
     )
     return result
 
 
 @jit(nopython=True)
-def is_point_on_easting_edge(easting, northing, upward, prism):
+def is_point_on_easting_edge(
+    easting,
+    northing,
+    upward,
+    prism_west,
+    prism_east,
+    prism_south,
+    prism_north,
+    prism_bottom,
+    prism_top,
+):
     """
     Check if observation point falls in a prism edge parallel to easting
 
@@ -112,16 +172,26 @@ def is_point_on_easting_edge(easting, northing, upward, prism):
         parallel to the easting direction or in any one of the vertices of the
         prism. Return False if otherwise.
     """
-    in_easting = prism[0] <= easting <= prism[1]
-    in_northing = (northing == prism[2]) or (northing == prism[3])
-    in_upward = (upward == prism[4]) or (upward == prism[5])
+    in_easting = prism_west <= easting <= prism_east
+    in_northing = northing in (prism_south, prism_north)
+    in_upward = upward in (prism_bottom, prism_top)
     if in_easting and in_northing and in_upward:
         return True
     return False
 
 
 @jit(nopython=True)
-def is_point_on_northing_edge(easting, northing, upward, prism):
+def is_point_on_northing_edge(
+    easting,
+    northing,
+    upward,
+    prism_west,
+    prism_east,
+    prism_south,
+    prism_north,
+    prism_bottom,
+    prism_top,
+):
     """
     Check if observation point falls in a prism edge parallel to northing
 
@@ -150,16 +220,26 @@ def is_point_on_northing_edge(easting, northing, upward, prism):
         parallel to the northing direction or in any one of the vertices of the
         prism. Return False if otherwise.
     """
-    in_easting = (easting == prism[0]) or (easting == prism[1])
-    in_northing = prism[2] <= northing <= prism[3]
-    in_upward = (upward == prism[4]) or (upward == prism[5])
+    in_easting = easting in (prism_west, prism_east)
+    in_northing = prism_south <= northing <= prism_north
+    in_upward = upward in (prism_bottom, prism_top)
     if in_easting and in_northing and in_upward:
         return True
     return False
 
 
 @jit(nopython=True)
-def is_point_on_upward_edge(easting, northing, upward, prism):
+def is_point_on_upward_edge(
+    easting,
+    northing,
+    upward,
+    prism_west,
+    prism_east,
+    prism_south,
+    prism_north,
+    prism_bottom,
+    prism_top,
+):
     """
     Check if observation point falls in a prism edge parallel to upward
 
@@ -188,16 +268,26 @@ def is_point_on_upward_edge(easting, northing, upward, prism):
         parallel to the upward direction or in any one of the vertices of the
         prism. Return False if otherwise.
     """
-    in_easting = (easting == prism[0]) or (easting == prism[1])
-    in_northing = (northing == prism[2]) or (northing == prism[3])
-    in_upward = prism[4] <= upward <= prism[5]
+    in_easting = easting in (prism_west, prism_east)
+    in_northing = northing in (prism_south, prism_north)
+    in_upward = prism_bottom <= upward <= prism_top
     if in_easting and in_northing and in_upward:
         return True
     return False
 
 
 @jit(nopython=True)
-def is_point_on_east_face(easting, northing, upward, prism):
+def is_point_on_east_face(
+    easting,
+    northing,
+    upward,
+    prism_west,  # noqa: U100
+    prism_east,
+    prism_south,
+    prism_north,
+    prism_bottom,
+    prism_top,
+):
     """
     Check if observation point falls in the eastern face of the prism
 
@@ -226,9 +316,9 @@ def is_point_on_east_face(easting, northing, upward, prism):
         the prism. Return False if otherwise.
     """
     on_east_face = (
-        (easting == prism[1])
-        and (prism[2] < northing < prism[3])
-        and (prism[4] < upward < prism[5])
+        (easting == prism_east)
+        and (prism_south < northing < prism_north)
+        and (prism_bottom < upward < prism_top)
     )
     if on_east_face:
         return True
@@ -236,7 +326,17 @@ def is_point_on_east_face(easting, northing, upward, prism):
 
 
 @jit(nopython=True)
-def is_point_on_north_face(easting, northing, upward, prism):
+def is_point_on_north_face(
+    easting,
+    northing,
+    upward,
+    prism_west,
+    prism_east,
+    prism_south,  # noqa: U100
+    prism_north,
+    prism_bottom,
+    prism_top,
+):
     """
     Check if observation point falls in the northern face of the prism
 
@@ -265,9 +365,9 @@ def is_point_on_north_face(easting, northing, upward, prism):
         the prism. Return False if otherwise.
     """
     on_north_face = (
-        (prism[0] < easting < prism[1])
-        and (northing == prism[3])
-        and (prism[4] < upward < prism[5])
+        (prism_west < easting < prism_east)
+        and (northing == prism_north)
+        and (prism_bottom < upward < prism_top)
     )
     if on_north_face:
         return True
@@ -275,7 +375,17 @@ def is_point_on_north_face(easting, northing, upward, prism):
 
 
 @jit(nopython=True)
-def is_point_on_top_face(easting, northing, upward, prism):
+def is_point_on_top_face(
+    easting,
+    northing,
+    upward,
+    prism_west,
+    prism_east,
+    prism_south,
+    prism_north,
+    prism_bottom,  # noqa: U100
+    prism_top,
+):
     """
     Check if observation point falls in the top face of the prism
 
@@ -303,9 +413,9 @@ def is_point_on_top_face(easting, northing, upward, prism):
         prism. Return False if otherwise.
     """
     on_top_face = (
-        (prism[0] < easting < prism[1])
-        and (prism[2] < northing < prism[3])
-        and (upward == prism[5])
+        (prism_west < easting < prism_east)
+        and (prism_south < northing < prism_north)
+        and (upward == prism_top)
     )
     if on_top_face:
         return True

--- a/choclo/tests/test_dipole.py
+++ b/choclo/tests/test_dipole.py
@@ -4,12 +4,6 @@
 #
 # This code is part of the Fatiando a Terra project (https://www.fatiando.org)
 #
-# Copyright (c) 2022 The Choclo Developers-.
-# Distributed under the terms of the BSD 3-Clause License.
-# SPDX-License-Identifier: BSD-3-Clause
-#
-# This code is part of the Fatiando a Terra project (https://www.fatiando.org)
-#
 """
 Test magnetic forward modelling functions for a dipole
 """
@@ -98,7 +92,7 @@ class TestSymmetryBe:
         magnetic_moment = np.array(magnetic_moment)
         b_e_top = np.array(
             list(
-                magnetic_e(e, n, u, *sample_dipole, magnetic_moment)
+                magnetic_e(e, n, u, *sample_dipole, *magnetic_moment)
                 for e, n, u in zip(
                     easting.ravel(), northing.ravel(), upward_top.ravel()
                 )
@@ -106,7 +100,7 @@ class TestSymmetryBe:
         )
         b_e_bottom = np.array(
             list(
-                magnetic_e(e, n, u, *sample_dipole, magnetic_moment)
+                magnetic_e(e, n, u, *sample_dipole, *magnetic_moment)
                 for e, n, u in zip(
                     easting.ravel(), northing.ravel(), upward_bottom.ravel()
                 )
@@ -148,7 +142,7 @@ class TestSymmetryBe:
         magnetic_moment = np.array(magnetic_moment)
         b_e_north = np.array(
             list(
-                magnetic_e(e, n, u, *sample_dipole, magnetic_moment)
+                magnetic_e(e, n, u, *sample_dipole, *magnetic_moment)
                 for e, n, u in zip(
                     easting.ravel(), northing_north.ravel(), upward.ravel()
                 )
@@ -156,7 +150,7 @@ class TestSymmetryBe:
         )
         b_e_south = np.array(
             list(
-                magnetic_e(e, n, u, *sample_dipole, magnetic_moment)
+                magnetic_e(e, n, u, *sample_dipole, *magnetic_moment)
                 for e, n, u in zip(
                     easting.ravel(), northing_south.ravel(), upward.ravel()
                 )
@@ -198,7 +192,7 @@ class TestSymmetryBe:
         magnetic_moment = np.array(magnetic_moment)
         b_e_east = np.array(
             list(
-                magnetic_e(e, n, u, *sample_dipole, magnetic_moment)
+                magnetic_e(e, n, u, *sample_dipole, *magnetic_moment)
                 for e, n, u in zip(
                     easting_east.ravel(), northing.ravel(), upward.ravel()
                 )
@@ -206,7 +200,7 @@ class TestSymmetryBe:
         )
         b_e_west = np.array(
             list(
-                magnetic_e(e, n, u, *sample_dipole, magnetic_moment)
+                magnetic_e(e, n, u, *sample_dipole, *magnetic_moment)
                 for e, n, u in zip(
                     easting_west.ravel(), northing.ravel(), upward.ravel()
                 )
@@ -235,13 +229,13 @@ class TestSymmetryBe:
         # observation points
         b_e_east = np.array(
             list(
-                magnetic_e(e, n, u, *sample_dipole, magnetic_moment_east)
+                magnetic_e(e, n, u, *sample_dipole, *magnetic_moment_east)
                 for e, n, u in zip(easting, northing, upward)
             )
         )
         b_e_west = np.array(
             list(
-                magnetic_e(e, n, u, *sample_dipole, magnetic_moment_west)
+                magnetic_e(e, n, u, *sample_dipole, *magnetic_moment_west)
                 for e, n, u in zip(easting, northing, upward)
             )
         )
@@ -286,7 +280,7 @@ class TestSymmetryBn:
         magnetic_moment = np.array(magnetic_moment)
         b_n_top = np.array(
             list(
-                magnetic_n(e, n, u, *sample_dipole, magnetic_moment)
+                magnetic_n(e, n, u, *sample_dipole, *magnetic_moment)
                 for e, n, u in zip(
                     easting.ravel(), northing.ravel(), upward_top.ravel()
                 )
@@ -294,7 +288,7 @@ class TestSymmetryBn:
         )
         b_n_bottom = np.array(
             list(
-                magnetic_n(e, n, u, *sample_dipole, magnetic_moment)
+                magnetic_n(e, n, u, *sample_dipole, *magnetic_moment)
                 for e, n, u in zip(
                     easting.ravel(), northing.ravel(), upward_bottom.ravel()
                 )
@@ -336,7 +330,7 @@ class TestSymmetryBn:
         magnetic_moment = np.array(magnetic_moment)
         b_n_north = np.array(
             list(
-                magnetic_n(e, n, u, *sample_dipole, magnetic_moment)
+                magnetic_n(e, n, u, *sample_dipole, *magnetic_moment)
                 for e, n, u in zip(
                     easting.ravel(), northing_north.ravel(), upward.ravel()
                 )
@@ -344,7 +338,7 @@ class TestSymmetryBn:
         )
         b_n_south = np.array(
             list(
-                magnetic_n(e, n, u, *sample_dipole, magnetic_moment)
+                magnetic_n(e, n, u, *sample_dipole, *magnetic_moment)
                 for e, n, u in zip(
                     easting.ravel(), northing_south.ravel(), upward.ravel()
                 )
@@ -386,7 +380,7 @@ class TestSymmetryBn:
         magnetic_moment = np.array(magnetic_moment)
         b_n_east = np.array(
             list(
-                magnetic_n(e, n, u, *sample_dipole, magnetic_moment)
+                magnetic_n(e, n, u, *sample_dipole, *magnetic_moment)
                 for e, n, u in zip(
                     easting_east.ravel(), northing.ravel(), upward.ravel()
                 )
@@ -394,7 +388,7 @@ class TestSymmetryBn:
         )
         b_n_west = np.array(
             list(
-                magnetic_n(e, n, u, *sample_dipole, magnetic_moment)
+                magnetic_n(e, n, u, *sample_dipole, *magnetic_moment)
                 for e, n, u in zip(
                     easting_west.ravel(), northing.ravel(), upward.ravel()
                 )
@@ -423,13 +417,13 @@ class TestSymmetryBn:
         # observation points
         b_n_north = np.array(
             list(
-                magnetic_n(e, n, u, *sample_dipole, magnetic_moment_north)
+                magnetic_n(e, n, u, *sample_dipole, *magnetic_moment_north)
                 for e, n, u in zip(easting, northing, upward)
             )
         )
         b_n_south = np.array(
             list(
-                magnetic_n(e, n, u, *sample_dipole, magnetic_moment_south)
+                magnetic_n(e, n, u, *sample_dipole, *magnetic_moment_south)
                 for e, n, u in zip(easting, northing, upward)
             )
         )
@@ -474,7 +468,7 @@ class TestSymmetryBu:
         magnetic_moment = np.array(magnetic_moment)
         b_u_top = np.array(
             list(
-                magnetic_u(e, n, u, *sample_dipole, magnetic_moment)
+                magnetic_u(e, n, u, *sample_dipole, *magnetic_moment)
                 for e, n, u in zip(
                     easting.ravel(), northing.ravel(), upward_top.ravel()
                 )
@@ -482,7 +476,7 @@ class TestSymmetryBu:
         )
         b_u_bottom = np.array(
             list(
-                magnetic_u(e, n, u, *sample_dipole, magnetic_moment)
+                magnetic_u(e, n, u, *sample_dipole, *magnetic_moment)
                 for e, n, u in zip(
                     easting.ravel(), northing.ravel(), upward_bottom.ravel()
                 )
@@ -524,7 +518,7 @@ class TestSymmetryBu:
         magnetic_moment = np.array(magnetic_moment)
         b_u_north = np.array(
             list(
-                magnetic_u(e, n, u, *sample_dipole, magnetic_moment)
+                magnetic_u(e, n, u, *sample_dipole, *magnetic_moment)
                 for e, n, u in zip(
                     easting.ravel(), northing_north.ravel(), upward.ravel()
                 )
@@ -532,7 +526,7 @@ class TestSymmetryBu:
         )
         b_u_south = np.array(
             list(
-                magnetic_u(e, n, u, *sample_dipole, magnetic_moment)
+                magnetic_u(e, n, u, *sample_dipole, *magnetic_moment)
                 for e, n, u in zip(
                     easting.ravel(), northing_south.ravel(), upward.ravel()
                 )
@@ -574,7 +568,7 @@ class TestSymmetryBu:
         magnetic_moment = np.array(magnetic_moment)
         b_u_east = np.array(
             list(
-                magnetic_u(e, n, u, *sample_dipole, magnetic_moment)
+                magnetic_u(e, n, u, *sample_dipole, *magnetic_moment)
                 for e, n, u in zip(
                     easting_east.ravel(), northing.ravel(), upward.ravel()
                 )
@@ -582,7 +576,7 @@ class TestSymmetryBu:
         )
         b_u_west = np.array(
             list(
-                magnetic_u(e, n, u, *sample_dipole, magnetic_moment)
+                magnetic_u(e, n, u, *sample_dipole, *magnetic_moment)
                 for e, n, u in zip(
                     easting_west.ravel(), northing.ravel(), upward.ravel()
                 )
@@ -611,13 +605,13 @@ class TestSymmetryBu:
         # observation points
         b_u_up = np.array(
             list(
-                magnetic_u(e, n, u, *sample_dipole, magnetic_moment_up)
+                magnetic_u(e, n, u, *sample_dipole, *magnetic_moment_up)
                 for e, n, u in zip(easting, northing, upward)
             )
         )
         b_u_down = np.array(
             list(
-                magnetic_u(e, n, u, *sample_dipole, magnetic_moment_down)
+                magnetic_u(e, n, u, *sample_dipole, *magnetic_moment_down)
                 for e, n, u in zip(easting, northing, upward)
             )
         )
@@ -643,7 +637,7 @@ class TestMagneticField:
         # Compute all components of B using magnetic_field
         b = np.array(
             list(
-                magnetic_field(e, n, u, *sample_dipole, sample_magnetic_moment)
+                magnetic_field(e, n, u, *sample_dipole, *sample_magnetic_moment)
                 for e, n, u in zip(*sample_3d_grid)
             )
         )
@@ -651,19 +645,19 @@ class TestMagneticField:
         # Computed the individual fields
         b_e_expected = np.array(
             list(
-                magnetic_e(e, n, u, *sample_dipole, sample_magnetic_moment)
+                magnetic_e(e, n, u, *sample_dipole, *sample_magnetic_moment)
                 for e, n, u in zip(*sample_3d_grid)
             )
         )
         b_n_expected = np.array(
             list(
-                magnetic_n(e, n, u, *sample_dipole, sample_magnetic_moment)
+                magnetic_n(e, n, u, *sample_dipole, *sample_magnetic_moment)
                 for e, n, u in zip(*sample_3d_grid)
             )
         )
         b_u_expected = np.array(
             list(
-                magnetic_u(e, n, u, *sample_dipole, sample_magnetic_moment)
+                magnetic_u(e, n, u, *sample_dipole, *sample_magnetic_moment)
                 for e, n, u in zip(*sample_3d_grid)
             )
         )
@@ -693,13 +687,13 @@ class TestDivergenceOfB:
         # Compute b_e on original and shifted coordinates
         b_e = np.array(
             list(
-                magnetic_e(e, n, u, *dipole, magnetic_moment)
+                magnetic_e(e, n, u, *dipole, *magnetic_moment)
                 for e, n, u in zip(easting, northing, upward)
             )
         )
         b_e_shifted = np.array(
             list(
-                magnetic_e(e, n, u, *dipole, magnetic_moment)
+                magnetic_e(e, n, u, *dipole, *magnetic_moment)
                 for e, n, u in zip(easting_shifted, northing, upward)
             )
         )
@@ -718,13 +712,13 @@ class TestDivergenceOfB:
         # Compute b_e on original and shifted coordinates
         b_n = np.array(
             list(
-                magnetic_n(e, n, u, *dipole, magnetic_moment)
+                magnetic_n(e, n, u, *dipole, *magnetic_moment)
                 for e, n, u in zip(easting, northing, upward)
             )
         )
         b_n_shifted = np.array(
             list(
-                magnetic_n(e, n, u, *dipole, magnetic_moment)
+                magnetic_n(e, n, u, *dipole, *magnetic_moment)
                 for e, n, u in zip(easting, northing_shifted, upward)
             )
         )
@@ -743,13 +737,13 @@ class TestDivergenceOfB:
         # Compute b_e on original and shifted coordinates
         b_u = np.array(
             list(
-                magnetic_u(e, n, u, *dipole, magnetic_moment)
+                magnetic_u(e, n, u, *dipole, *magnetic_moment)
                 for e, n, u in zip(easting, northing, upward)
             )
         )
         b_u_shifted = np.array(
             list(
-                magnetic_u(e, n, u, *dipole, magnetic_moment)
+                magnetic_u(e, n, u, *dipole, *magnetic_moment)
                 for e, n, u in zip(easting, northing, upward_shifted)
             )
         )

--- a/choclo/tests/test_prism_gravity.py
+++ b/choclo/tests/test_prism_gravity.py
@@ -254,7 +254,7 @@ class TestSymmetryPotential:
         """
         # Compute gravity_pot on every observation point of the symmetry group
         potential = list(
-            gravity_pot(e, n, u, sample_prism, sample_density)
+            gravity_pot(e, n, u, *sample_prism, sample_density)
             for e, n, u in coords_in_vertices
         )
         npt.assert_allclose(potential[0], potential)
@@ -268,7 +268,7 @@ class TestSymmetryPotential:
         """
         # Compute gravity_pot on every observation point of the symmetry group
         potential = list(
-            gravity_pot(e, n, u, sample_prism, sample_density)
+            gravity_pot(e, n, u, *sample_prism, sample_density)
             for e, n, u in coords_in_centers_of_easting_edges
         )
         npt.assert_allclose(potential[0], potential)
@@ -282,7 +282,7 @@ class TestSymmetryPotential:
         """
         # Compute gravity_pot on every observation point of the symmetry group
         potential = list(
-            gravity_pot(e, n, u, sample_prism, sample_density)
+            gravity_pot(e, n, u, *sample_prism, sample_density)
             for e, n, u in coords_in_centers_of_northing_edges
         )
         npt.assert_allclose(potential[0], potential)
@@ -296,7 +296,7 @@ class TestSymmetryPotential:
         """
         # Compute gravity_pot on every observation point of the symmetry group
         potential = list(
-            gravity_pot(e, n, u, sample_prism, sample_density)
+            gravity_pot(e, n, u, *sample_prism, sample_density)
             for e, n, u in coords_in_centers_of_upward_edges
         )
         npt.assert_allclose(potential[0], potential)
@@ -310,7 +310,7 @@ class TestSymmetryPotential:
         """
         # Compute gravity_pot on every observation point of the symmetry group
         potential = list(
-            gravity_pot(e, n, u, sample_prism, sample_density)
+            gravity_pot(e, n, u, *sample_prism, sample_density)
             for e, n, u in coords_in_centers_of_easting_faces
         )
         npt.assert_allclose(potential[0], potential)
@@ -324,7 +324,7 @@ class TestSymmetryPotential:
         """
         # Compute gravity_pot on every observation point of the symmetry group
         potential = list(
-            gravity_pot(e, n, u, sample_prism, sample_density)
+            gravity_pot(e, n, u, *sample_prism, sample_density)
             for e, n, u in coords_in_centers_of_northing_faces
         )
         npt.assert_allclose(potential[0], potential)
@@ -338,7 +338,7 @@ class TestSymmetryPotential:
         """
         # Compute gravity_pot on every observation point of the symmetry group
         potential = list(
-            gravity_pot(e, n, u, sample_prism, sample_density)
+            gravity_pot(e, n, u, *sample_prism, sample_density)
             for e, n, u in coords_in_centers_of_upward_faces
         )
         npt.assert_allclose(potential[0], potential)
@@ -417,14 +417,14 @@ class TestSymmetryGravityE:
         """
         # Compute gravity_e on every observation point of northing-upward plane
         g_e = list(
-            gravity_e(e, n, u, sample_prism, sample_density)
+            gravity_e(e, n, u, *sample_prism, sample_density)
             for e, n, u in zip(*coords_in_northing_upward_plane)
         )
         # Compute gravity_e on a point slightly shifted from the prism center
         # (it will be our control for non-zero field)
         easting, northing, upward = sample_prism_center
         non_zero_g_e = gravity_e(
-            easting + 1e-10, northing, upward, sample_prism, sample_density
+            easting + 1e-10, northing, upward, *sample_prism, sample_density
         )
         atol = np.abs(non_zero_g_e).max()
         npt.assert_allclose(g_e, 0, atol=atol)
@@ -438,13 +438,13 @@ class TestSymmetryGravityE:
         # Compute gravity_e on every observation point of the two planes
         g_e_west = np.array(
             list(
-                gravity_e(e, n, u, sample_prism, sample_density)
+                gravity_e(e, n, u, *sample_prism, sample_density)
                 for e, n, u in zip(*west)
             )
         )
         g_e_east = np.array(
             list(
-                gravity_e(e, n, u, sample_prism, sample_density)
+                gravity_e(e, n, u, *sample_prism, sample_density)
                 for e, n, u in zip(*east)
             )
         )
@@ -466,7 +466,7 @@ class TestSymmetryGravityE:
             sample_prism_center[2],
         )
         # Compute gravity_e
-        g_e = gravity_e(*point, sample_prism, density)
+        g_e = gravity_e(*point, *sample_prism, density)
         # Check if g_e has the opposite sign as its density (the acceleration
         # will point westward for a positive density, therefore negative
         # easting component)
@@ -483,10 +483,16 @@ class TestSymmetryGravityE:
         east_vertices = [[east, n, u] for n in (south, north) for u in (bottom, top)]
         west_vertices = [[west, n, u] for n in (south, north) for u in (bottom, top)]
         g_e_east = np.array(
-            [gravity_e(*point, sample_prism, sample_density) for point in east_vertices]
+            [
+                gravity_e(*point, *sample_prism, sample_density)
+                for point in east_vertices
+            ]
         )
         g_e_west = np.array(
-            [gravity_e(*point, sample_prism, sample_density) for point in west_vertices]
+            [
+                gravity_e(*point, *sample_prism, sample_density)
+                for point in west_vertices
+            ]
         )
         npt.assert_allclose(g_e_east, -g_e_west)
 
@@ -564,14 +570,14 @@ class TestSymmetryGravityN:
         """
         # Compute gravity_n on every observation point of easting-upward plane
         g_n = list(
-            gravity_n(e, n, u, sample_prism, sample_density)
+            gravity_n(e, n, u, *sample_prism, sample_density)
             for e, n, u in zip(*coords_in_easting_upward_plane)
         )
         # Compute gravity_n on a point slightly shifted from the prism center
         # (it will be our control for non-zero field)
         easting, northing, upward = sample_prism_center
         non_zero_g_n = gravity_n(
-            easting, northing + 1e-10, upward, sample_prism, sample_density
+            easting, northing + 1e-10, upward, *sample_prism, sample_density
         )
         atol = np.abs(non_zero_g_n).max()
         npt.assert_allclose(g_n, 0, atol=atol)
@@ -585,13 +591,13 @@ class TestSymmetryGravityN:
         # Compute gravity_n on every observation point of the two planes
         g_n_south = np.array(
             list(
-                gravity_n(e, n, u, sample_prism, sample_density)
+                gravity_n(e, n, u, *sample_prism, sample_density)
                 for e, n, u in zip(*south)
             )
         )
         g_n_north = np.array(
             list(
-                gravity_n(e, n, u, sample_prism, sample_density)
+                gravity_n(e, n, u, *sample_prism, sample_density)
                 for e, n, u in zip(*north)
             )
         )
@@ -613,7 +619,7 @@ class TestSymmetryGravityN:
             sample_prism_center[2],
         )
         # Compute gravity_e
-        g_n = gravity_n(*point, sample_prism, density)
+        g_n = gravity_n(*point, *sample_prism, density)
         # Check if g_n has the opposite sign as its density (the acceleration
         # will point southward for a positive density, therefore negative
         # northing component)
@@ -631,13 +637,13 @@ class TestSymmetryGravityN:
         south_vertices = [[e, north, u] for e in (west, east) for u in (bottom, top)]
         g_n_north = np.array(
             [
-                gravity_n(*point, sample_prism, sample_density)
+                gravity_n(*point, *sample_prism, sample_density)
                 for point in north_vertices
             ]
         )
         g_n_south = np.array(
             [
-                gravity_n(*point, sample_prism, sample_density)
+                gravity_n(*point, *sample_prism, sample_density)
                 for point in south_vertices
             ]
         )
@@ -718,14 +724,14 @@ class TestSymmetryGravityU:
         # Compute gravity_u on every observation point of the easting-northing
         # plane
         g_u = list(
-            gravity_u(e, n, u, sample_prism, sample_density)
+            gravity_u(e, n, u, *sample_prism, sample_density)
             for e, n, u in zip(*coords_in_easting_northing_plane)
         )
         # Compute gravity_u on a point slightly shifted from the prism center
         # (it will be our control for non-zero field)
         easting, northing, upward = sample_prism_center
         non_zero_g_u = gravity_u(
-            easting, northing, upward + 1e-10, sample_prism, sample_density
+            easting, northing, upward + 1e-10, *sample_prism, sample_density
         )
         atol = np.abs(non_zero_g_u).max()
         npt.assert_allclose(g_u, 0, atol=atol)
@@ -739,13 +745,13 @@ class TestSymmetryGravityU:
         # Compute gravity_u on every observation point of the two planes
         g_u_bottom = np.array(
             list(
-                gravity_u(e, n, u, sample_prism, sample_density)
+                gravity_u(e, n, u, *sample_prism, sample_density)
                 for e, n, u in zip(*bottom)
             )
         )
         g_u_top = np.array(
             list(
-                gravity_u(e, n, u, sample_prism, sample_density)
+                gravity_u(e, n, u, *sample_prism, sample_density)
                 for e, n, u in zip(*top)
             )
         )
@@ -767,7 +773,7 @@ class TestSymmetryGravityU:
             sample_prism_center[2] + d_upward,
         )
         # Compute gravity_u
-        g_u = gravity_u(*point, sample_prism, density)
+        g_u = gravity_u(*point, *sample_prism, density)
         # Check if g_u has the opposite sign as its density (the acceleration
         # will point downwards for a positive density, therefore negative
         # upward component)
@@ -784,11 +790,11 @@ class TestSymmetryGravityU:
         top_vertices = [[e, n, top] for e in (west, east) for n in (south, north)]
         bottom_vertices = [[e, n, bottom] for e in (west, east) for n in (south, north)]
         g_u_top = np.array(
-            [gravity_u(*point, sample_prism, sample_density) for point in top_vertices]
+            [gravity_u(*point, *sample_prism, sample_density) for point in top_vertices]
         )
         g_u_bottom = np.array(
             [
-                gravity_u(*point, sample_prism, sample_density)
+                gravity_u(*point, *sample_prism, sample_density)
                 for point in bottom_vertices
             ]
         )
@@ -818,8 +824,8 @@ class TestAccelerationFiniteDifferences:
         shifted_coordinate = (easting_p + self.delta, northing_p, upward_p)
         # Calculate g_e through finite differences
         g_e = (
-            gravity_pot(*shifted_coordinate, sample_prism, sample_density)
-            - gravity_pot(*sample_coordinate, sample_prism, sample_density)
+            gravity_pot(*shifted_coordinate, *sample_prism, sample_density)
+            - gravity_pot(*sample_coordinate, *sample_prism, sample_density)
         ) / self.delta
         return g_e
 
@@ -834,8 +840,8 @@ class TestAccelerationFiniteDifferences:
         shifted_coordinate = (easting_p, northing_p + self.delta, upward_p)
         # Calculate g_n through finite differences
         g_n = (
-            gravity_pot(*shifted_coordinate, sample_prism, sample_density)
-            - gravity_pot(*sample_coordinate, sample_prism, sample_density)
+            gravity_pot(*shifted_coordinate, *sample_prism, sample_density)
+            - gravity_pot(*sample_coordinate, *sample_prism, sample_density)
         ) / self.delta
         return g_n
 
@@ -850,8 +856,8 @@ class TestAccelerationFiniteDifferences:
         shifted_coordinate = (easting_p, northing_p, upward_p + self.delta)
         # Calculate g_u through finite differences
         g_u = (
-            gravity_pot(*shifted_coordinate, sample_prism, sample_density)
-            - gravity_pot(*sample_coordinate, sample_prism, sample_density)
+            gravity_pot(*shifted_coordinate, *sample_prism, sample_density)
+            - gravity_pot(*sample_coordinate, *sample_prism, sample_density)
         ) / self.delta
         return g_u
 
@@ -861,7 +867,7 @@ class TestAccelerationFiniteDifferences:
         """
         Test gravity_e against finite differences of the gravity_pot
         """
-        g_e = gravity_e(*sample_coordinate, sample_prism, sample_density)
+        g_e = gravity_e(*sample_coordinate, *sample_prism, sample_density)
         npt.assert_allclose(g_e, finite_diff_gravity_e, rtol=self.rtol)
 
     def test_gravity_n(
@@ -870,7 +876,7 @@ class TestAccelerationFiniteDifferences:
         """
         Test gravity_n against finite differences of the gravity_pot
         """
-        g_n = gravity_n(*sample_coordinate, sample_prism, sample_density)
+        g_n = gravity_n(*sample_coordinate, *sample_prism, sample_density)
         npt.assert_allclose(g_n, finite_diff_gravity_n, rtol=self.rtol)
 
     def test_gravity_u(
@@ -879,7 +885,7 @@ class TestAccelerationFiniteDifferences:
         """
         Test gravity_u against finite differences of the gravity_pot
         """
-        g_u = gravity_u(*sample_coordinate, sample_prism, sample_density)
+        g_u = gravity_u(*sample_coordinate, *sample_prism, sample_density)
         npt.assert_allclose(g_u, finite_diff_gravity_u, rtol=self.rtol)
 
 
@@ -906,8 +912,8 @@ class TestTensorFiniteDifferences:
         shifted_coordinate = (easting_p + self.delta, northing_p, upward_p)
         # Calculate g_ee through finite differences
         g_ee = (
-            gravity_e(*shifted_coordinate, sample_prism, sample_density)
-            - gravity_e(*sample_coordinate, sample_prism, sample_density)
+            gravity_e(*shifted_coordinate, *sample_prism, sample_density)
+            - gravity_e(*sample_coordinate, *sample_prism, sample_density)
         ) / self.delta
         return g_ee
 
@@ -922,8 +928,8 @@ class TestTensorFiniteDifferences:
         shifted_coordinate = (easting_p, northing_p + self.delta, upward_p)
         # Calculate g_nn through finite differences
         g_nn = (
-            gravity_n(*shifted_coordinate, sample_prism, sample_density)
-            - gravity_n(*sample_coordinate, sample_prism, sample_density)
+            gravity_n(*shifted_coordinate, *sample_prism, sample_density)
+            - gravity_n(*sample_coordinate, *sample_prism, sample_density)
         ) / self.delta
         return g_nn
 
@@ -938,8 +944,8 @@ class TestTensorFiniteDifferences:
         shifted_coordinate = (easting_p, northing_p, upward_p + self.delta)
         # Calculate g_u through finite differences
         g_uu = (
-            gravity_u(*shifted_coordinate, sample_prism, sample_density)
-            - gravity_u(*sample_coordinate, sample_prism, sample_density)
+            gravity_u(*shifted_coordinate, *sample_prism, sample_density)
+            - gravity_u(*sample_coordinate, *sample_prism, sample_density)
         ) / self.delta
         return g_uu
 
@@ -954,8 +960,8 @@ class TestTensorFiniteDifferences:
         shifted_coordinate = (easting_p, northing_p + self.delta, upward_p)
         # Calculate g_en through finite differences
         g_en = (
-            gravity_e(*shifted_coordinate, sample_prism, sample_density)
-            - gravity_e(*sample_coordinate, sample_prism, sample_density)
+            gravity_e(*shifted_coordinate, *sample_prism, sample_density)
+            - gravity_e(*sample_coordinate, *sample_prism, sample_density)
         ) / self.delta
         return g_en
 
@@ -970,8 +976,8 @@ class TestTensorFiniteDifferences:
         shifted_coordinate = (easting_p, northing_p, upward_p + self.delta)
         # Calculate g_en through finite differences
         g_eu = (
-            gravity_e(*shifted_coordinate, sample_prism, sample_density)
-            - gravity_e(*sample_coordinate, sample_prism, sample_density)
+            gravity_e(*shifted_coordinate, *sample_prism, sample_density)
+            - gravity_e(*sample_coordinate, *sample_prism, sample_density)
         ) / self.delta
         return g_eu
 
@@ -986,8 +992,8 @@ class TestTensorFiniteDifferences:
         shifted_coordinate = (easting_p, northing_p, upward_p + self.delta)
         # Calculate g_en through finite differences
         g_nu = (
-            gravity_n(*shifted_coordinate, sample_prism, sample_density)
-            - gravity_n(*sample_coordinate, sample_prism, sample_density)
+            gravity_n(*shifted_coordinate, *sample_prism, sample_density)
+            - gravity_n(*sample_coordinate, *sample_prism, sample_density)
         ) / self.delta
         return g_nu
 
@@ -997,7 +1003,7 @@ class TestTensorFiniteDifferences:
         """
         Test gravity_ee against finite differences of the gravity_e
         """
-        g_ee = gravity_ee(*sample_coordinate, sample_prism, sample_density)
+        g_ee = gravity_ee(*sample_coordinate, *sample_prism, sample_density)
         npt.assert_allclose(g_ee, finite_diff_gravity_ee, rtol=self.rtol)
 
     def test_gravity_nn(
@@ -1006,7 +1012,7 @@ class TestTensorFiniteDifferences:
         """
         Test gravity_nn against finite differences of the gravity_n
         """
-        g_nn = gravity_nn(*sample_coordinate, sample_prism, sample_density)
+        g_nn = gravity_nn(*sample_coordinate, *sample_prism, sample_density)
         npt.assert_allclose(g_nn, finite_diff_gravity_nn, rtol=self.rtol)
 
     def test_gravity_uu(
@@ -1015,7 +1021,7 @@ class TestTensorFiniteDifferences:
         """
         Test gravity_uu against finite differences of the gravity_u
         """
-        g_uu = gravity_uu(*sample_coordinate, sample_prism, sample_density)
+        g_uu = gravity_uu(*sample_coordinate, *sample_prism, sample_density)
         npt.assert_allclose(g_uu, finite_diff_gravity_uu, rtol=self.rtol)
 
     def test_gravity_en(
@@ -1024,7 +1030,7 @@ class TestTensorFiniteDifferences:
         """
         Test gravity_en against finite differences of the gravity_e
         """
-        g_en = gravity_en(*sample_coordinate, sample_prism, sample_density)
+        g_en = gravity_en(*sample_coordinate, *sample_prism, sample_density)
         npt.assert_allclose(g_en, finite_diff_gravity_en, rtol=self.rtol)
 
     def test_gravity_eu(
@@ -1033,7 +1039,7 @@ class TestTensorFiniteDifferences:
         """
         Test gravity_eu against finite differences of the gravity_e
         """
-        g_eu = gravity_eu(*sample_coordinate, sample_prism, sample_density)
+        g_eu = gravity_eu(*sample_coordinate, *sample_prism, sample_density)
         npt.assert_allclose(g_eu, finite_diff_gravity_eu, rtol=self.rtol)
 
     def test_gravity_nu(
@@ -1042,7 +1048,7 @@ class TestTensorFiniteDifferences:
         """
         Test gravity_nu against finite differences of the gravity_n
         """
-        g_nu = gravity_nu(*sample_coordinate, sample_prism, sample_density)
+        g_nu = gravity_nu(*sample_coordinate, *sample_prism, sample_density)
         npt.assert_allclose(g_nu, finite_diff_gravity_nu, rtol=self.rtol)
 
 
@@ -1092,19 +1098,19 @@ class TestLaplacian:
         """
         g_ee = np.array(
             [
-                gravity_ee(e, n, u, sample_prism, sample_density)
+                gravity_ee(e, n, u, *sample_prism, sample_density)
                 for e, n, u in zip(*sample_observation_points)
             ]
         )
         g_nn = np.array(
             [
-                gravity_nn(e, n, u, sample_prism, sample_density)
+                gravity_nn(e, n, u, *sample_prism, sample_density)
                 for e, n, u in zip(*sample_observation_points)
             ]
         )
         g_uu = np.array(
             [
-                gravity_uu(e, n, u, sample_prism, sample_density)
+                gravity_uu(e, n, u, *sample_prism, sample_density)
                 for e, n, u in zip(*sample_observation_points)
             ]
         )
@@ -1165,7 +1171,7 @@ class TestNonDiagonalTensor:
         upward = prism[5] + 1  # locate the observation points above the prism
         g_en = np.array(
             [
-                gravity_en(e, n, upward, prism, density)
+                gravity_en(e, n, upward, *prism, density)
                 for e in easting
                 for n in northing
             ]
@@ -1192,7 +1198,7 @@ class TestNonDiagonalTensor:
         northing = prism[3] + 1  # locate the observation points north the prism
         g_eu = np.array(
             [
-                gravity_eu(e, northing, u, prism, density)
+                gravity_eu(e, northing, u, *prism, density)
                 for e in easting
                 for u in upward
             ]
@@ -1219,7 +1225,7 @@ class TestNonDiagonalTensor:
         easting = prism[1] + 1  # locate the observation points north the prism
         g_nu = np.array(
             [
-                gravity_nu(easting, n, u, prism, density)
+                gravity_nu(easting, n, u, *prism, density)
                 for n in northing
                 for u in upward
             ]
@@ -1273,14 +1279,14 @@ class TestNonDiagonalTensorSymmetry:
         delta = 2
         g_en_top = np.array(
             [
-                gravity_en(e, n, top + delta, prism, density)
+                gravity_en(e, n, top + delta, *prism, density)
                 for e in easting
                 for n in northing
             ]
         )
         g_en_bottom = np.array(
             [
-                gravity_en(e, n, bottom - delta, prism, density)
+                gravity_en(e, n, bottom - delta, *prism, density)
                 for e in easting
                 for n in northing
             ]
@@ -1302,14 +1308,14 @@ class TestNonDiagonalTensorSymmetry:
         delta = 2
         g_eu_north = np.array(
             [
-                gravity_eu(e, north + delta, u, prism, density)
+                gravity_eu(e, north + delta, u, *prism, density)
                 for e in easting
                 for u in upward
             ]
         )
         g_eu_south = np.array(
             [
-                gravity_eu(e, south - delta, u, prism, density)
+                gravity_eu(e, south - delta, u, *prism, density)
                 for e in easting
                 for u in upward
             ]
@@ -1331,14 +1337,14 @@ class TestNonDiagonalTensorSymmetry:
         delta = 2
         g_nu_north = np.array(
             [
-                gravity_nu(east + delta, n, u, prism, density)
+                gravity_nu(east + delta, n, u, *prism, density)
                 for n in northing
                 for u in upward
             ]
         )
         g_nu_south = np.array(
             [
-                gravity_nu(west - delta, n, u, prism, density)
+                gravity_nu(west - delta, n, u, *prism, density)
                 for n in northing
                 for u in upward
             ]
@@ -1381,7 +1387,7 @@ class TestDiagonalTensorSingularities:
             a.ravel() for a in np.meshgrid([west, east], [south, north], [bottom, top])
         )
         results = list(
-            function(e, n, u, prism, density) for (e, n, u) in zip(*coordinates)
+            function(e, n, u, *prism, density) for (e, n, u) in zip(*coordinates)
         )
         assert np.isnan(results).all()
 
@@ -1401,7 +1407,7 @@ class TestDiagonalTensorSingularities:
             easting, (south + north) / 2
         )  # put points in the center of the edge
         results = list(
-            gravity_ee(e, n, u, prism, density)
+            gravity_ee(e, n, u, *prism, density)
             for (e, n, u) in zip(easting, northing, upward)
         )
         assert np.isnan(results).all()
@@ -1413,7 +1419,7 @@ class TestDiagonalTensorSingularities:
             easting, (bottom + top) / 2
         )  # put points in the center of the edge
         results = list(
-            gravity_ee(e, n, u, prism, density)
+            gravity_ee(e, n, u, *prism, density)
             for (e, n, u) in zip(easting, northing, upward)
         )
         assert np.isnan(results).all()
@@ -1434,7 +1440,7 @@ class TestDiagonalTensorSingularities:
             northing, (west + east) / 2
         )  # put points in the center of the edge
         results = list(
-            gravity_nn(e, n, u, prism, density)
+            gravity_nn(e, n, u, *prism, density)
             for (e, n, u) in zip(easting, northing, upward)
         )
         assert np.isnan(results).all()
@@ -1446,7 +1452,7 @@ class TestDiagonalTensorSingularities:
             easting, (bottom + top) / 2
         )  # put points in the center of the edge
         results = list(
-            gravity_nn(e, n, u, prism, density)
+            gravity_nn(e, n, u, *prism, density)
             for (e, n, u) in zip(easting, northing, upward)
         )
         assert np.isnan(results).all()
@@ -1467,7 +1473,7 @@ class TestDiagonalTensorSingularities:
             northing, (west + east) / 2
         )  # put points in the center of the edge
         results = list(
-            gravity_uu(e, n, u, prism, density)
+            gravity_uu(e, n, u, *prism, density)
             for (e, n, u) in zip(easting, northing, upward)
         )
         assert np.isnan(results).all()
@@ -1479,7 +1485,7 @@ class TestDiagonalTensorSingularities:
             easting, (south + north) / 2
         )  # put points in the center of the edge
         results = list(
-            gravity_ee(e, n, u, prism, density)
+            gravity_ee(e, n, u, *prism, density)
             for (e, n, u) in zip(easting, northing, upward)
         )
         assert np.isnan(results).all()
@@ -1500,11 +1506,11 @@ class TestDiagonalTensorSingularities:
         east_face = np.full_like(northing, east)
         west_face = np.full_like(northing, west)
         result_east_face = list(
-            gravity_ee(e, n, u, prism, density)
+            gravity_ee(e, n, u, *prism, density)
             for (e, n, u) in zip(east_face, northing, upward)
         )
         result_west_face = list(
-            gravity_ee(e, n, u, prism, density)
+            gravity_ee(e, n, u, *prism, density)
             for (e, n, u) in zip(west_face, northing, upward)
         )
         npt.assert_allclose(result_east_face, result_west_face)
@@ -1521,8 +1527,8 @@ class TestDiagonalTensorSingularities:
         # Compute g_ee on the east face and on a slightly displaced point
         northing = (south + north) / 2
         upward = (bottom + top) / 2
-        g_ee_on_face = gravity_ee(east, northing, upward, prism, density)
-        g_ee_close_to_face = gravity_ee(east + 1e-3, northing, upward, prism, density)
+        g_ee_on_face = gravity_ee(east, northing, upward, *prism, density)
+        g_ee_close_to_face = gravity_ee(east + 1e-3, northing, upward, *prism, density)
         # Compare the results
         assert np.sign(g_ee_on_face) == np.sign(g_ee_close_to_face)
 
@@ -1538,8 +1544,8 @@ class TestDiagonalTensorSingularities:
         # Compute g_nn on the north face and on a slightly displaced point
         easting = (west + east) / 2
         upward = (bottom + top) / 2
-        g_nn_on_face = gravity_ee(easting, north, upward, prism, density)
-        g_nn_close_to_face = gravity_ee(easting, north + 1e-3, upward, prism, density)
+        g_nn_on_face = gravity_ee(easting, north, upward, *prism, density)
+        g_nn_close_to_face = gravity_ee(easting, north + 1e-3, upward, *prism, density)
         # Compare the results
         assert np.sign(g_nn_on_face) == np.sign(g_nn_close_to_face)
 
@@ -1555,8 +1561,8 @@ class TestDiagonalTensorSingularities:
         # Compute g_uu on the top face and on a slightly displaced point
         easting = (west + east) / 2
         northing = (south + north) / 2
-        g_uu_on_face = gravity_ee(easting, northing, top, prism, density)
-        g_uu_close_to_face = gravity_ee(easting, northing, top + 1e-3, prism, density)
+        g_uu_on_face = gravity_ee(easting, northing, top, *prism, density)
+        g_uu_close_to_face = gravity_ee(easting, northing, top + 1e-3, *prism, density)
         # Compare the results
         assert np.sign(g_uu_on_face) == np.sign(g_uu_close_to_face)
 
@@ -1576,11 +1582,11 @@ class TestDiagonalTensorSingularities:
         south_face = np.full_like(easting, south)
         north_face = np.full_like(easting, north)
         result_north_face = list(
-            gravity_nn(e, n, u, prism, density)
+            gravity_nn(e, n, u, *prism, density)
             for (e, n, u) in zip(easting, north_face, upward)
         )
         result_south_face = list(
-            gravity_nn(e, n, u, prism, density)
+            gravity_nn(e, n, u, *prism, density)
             for (e, n, u) in zip(easting, south_face, upward)
         )
         npt.assert_allclose(result_north_face, result_south_face)
@@ -1601,11 +1607,11 @@ class TestDiagonalTensorSingularities:
         top_face = np.full_like(easting, top)
         bottom_face = np.full_like(easting, bottom)
         result_top_face = list(
-            gravity_uu(e, n, u, prism, density)
+            gravity_uu(e, n, u, *prism, density)
             for (e, n, u) in zip(easting, northing, top_face)
         )
         result_bottom_face = list(
-            gravity_uu(e, n, u, prism, density)
+            gravity_uu(e, n, u, *prism, density)
             for (e, n, u) in zip(easting, northing, bottom_face)
         )
         npt.assert_allclose(result_top_face, result_bottom_face)
@@ -1643,7 +1649,7 @@ class TestNonDiagonalTensorSingularities:
             a.ravel() for a in np.meshgrid([west, east], [south, north], [bottom, top])
         )
         results = list(
-            function(e, n, u, prism, density) for (e, n, u) in zip(*coordinates)
+            function(e, n, u, *prism, density) for (e, n, u) in zip(*coordinates)
         )
         assert np.isnan(results).all()
 
@@ -1663,7 +1669,7 @@ class TestNonDiagonalTensorSingularities:
             easting, (bottom + top) / 2
         )  # put points in the center of the edge
         results = list(
-            gravity_en(e, n, u, prism, density)
+            gravity_en(e, n, u, *prism, density)
             for (e, n, u) in zip(easting, northing, upward)
         )
         assert np.isnan(results).all()
@@ -1684,7 +1690,7 @@ class TestNonDiagonalTensorSingularities:
             easting, (south + north) / 2
         )  # put points in the center of the edge
         results = list(
-            gravity_eu(e, n, u, prism, density)
+            gravity_eu(e, n, u, *prism, density)
             for (e, n, u) in zip(easting, northing, upward)
         )
         assert np.isnan(results).all()
@@ -1705,7 +1711,7 @@ class TestNonDiagonalTensorSingularities:
             northing, (west + east) / 2
         )  # put points in the center of the edge
         results = list(
-            gravity_nu(e, n, u, prism, density)
+            gravity_nu(e, n, u, *prism, density)
             for (e, n, u) in zip(easting, northing, upward)
         )
         assert np.isnan(results).all()

--- a/choclo/tests/test_prism_magnetic.py
+++ b/choclo/tests/test_prism_magnetic.py
@@ -107,7 +107,7 @@ class TestSymmetryBe:
         magnetization = np.array(magnetization)
         b_e_top = np.array(
             list(
-                magnetic_e(e, n, u, sample_prism, magnetization)
+                magnetic_e(e, n, u, *sample_prism, *magnetization)
                 for e, n, u in zip(
                     easting.ravel(), northing.ravel(), upward_top.ravel()
                 )
@@ -115,7 +115,7 @@ class TestSymmetryBe:
         )
         b_e_bottom = np.array(
             list(
-                magnetic_e(e, n, u, sample_prism, magnetization)
+                magnetic_e(e, n, u, *sample_prism, *magnetization)
                 for e, n, u in zip(
                     easting.ravel(), northing.ravel(), upward_bottom.ravel()
                 )
@@ -159,7 +159,7 @@ class TestSymmetryBe:
         magnetization = np.array(magnetization)
         b_e_north = np.array(
             list(
-                magnetic_e(e, n, u, sample_prism, magnetization)
+                magnetic_e(e, n, u, *sample_prism, *magnetization)
                 for e, n, u in zip(
                     easting.ravel(), northing_north.ravel(), upward.ravel()
                 )
@@ -167,7 +167,7 @@ class TestSymmetryBe:
         )
         b_e_south = np.array(
             list(
-                magnetic_e(e, n, u, sample_prism, magnetization)
+                magnetic_e(e, n, u, *sample_prism, *magnetization)
                 for e, n, u in zip(
                     easting.ravel(), northing_south.ravel(), upward.ravel()
                 )
@@ -211,7 +211,7 @@ class TestSymmetryBe:
         magnetization = np.array(magnetization)
         b_e_east = np.array(
             list(
-                magnetic_e(e, n, u, sample_prism, magnetization)
+                magnetic_e(e, n, u, *sample_prism, *magnetization)
                 for e, n, u in zip(
                     easting_east.ravel(), northing.ravel(), upward.ravel()
                 )
@@ -219,7 +219,7 @@ class TestSymmetryBe:
         )
         b_e_west = np.array(
             list(
-                magnetic_e(e, n, u, sample_prism, magnetization)
+                magnetic_e(e, n, u, *sample_prism, *magnetization)
                 for e, n, u in zip(
                     easting_west.ravel(), northing.ravel(), upward.ravel()
                 )
@@ -249,13 +249,13 @@ class TestSymmetryBe:
         # observation points
         b_e_east = np.array(
             list(
-                magnetic_e(e, n, u, sample_prism, magnetization_east)
+                magnetic_e(e, n, u, *sample_prism, *magnetization_east)
                 for e, n, u in zip(easting, northing, upward)
             )
         )
         b_e_west = np.array(
             list(
-                magnetic_e(e, n, u, sample_prism, magnetization_west)
+                magnetic_e(e, n, u, *sample_prism, *magnetization_west)
                 for e, n, u in zip(easting, northing, upward)
             )
         )
@@ -302,7 +302,7 @@ class TestSymmetryBn:
         magnetization = np.array(magnetization)
         b_n_top = np.array(
             list(
-                magnetic_n(e, n, u, sample_prism, magnetization)
+                magnetic_n(e, n, u, *sample_prism, *magnetization)
                 for e, n, u in zip(
                     easting.ravel(), northing.ravel(), upward_top.ravel()
                 )
@@ -310,7 +310,7 @@ class TestSymmetryBn:
         )
         b_n_bottom = np.array(
             list(
-                magnetic_n(e, n, u, sample_prism, magnetization)
+                magnetic_n(e, n, u, *sample_prism, *magnetization)
                 for e, n, u in zip(
                     easting.ravel(), northing.ravel(), upward_bottom.ravel()
                 )
@@ -354,7 +354,7 @@ class TestSymmetryBn:
         magnetization = np.array(magnetization)
         b_n_north = np.array(
             list(
-                magnetic_n(e, n, u, sample_prism, magnetization)
+                magnetic_n(e, n, u, *sample_prism, *magnetization)
                 for e, n, u in zip(
                     easting.ravel(), northing_north.ravel(), upward.ravel()
                 )
@@ -362,7 +362,7 @@ class TestSymmetryBn:
         )
         b_n_south = np.array(
             list(
-                magnetic_n(e, n, u, sample_prism, magnetization)
+                magnetic_n(e, n, u, *sample_prism, *magnetization)
                 for e, n, u in zip(
                     easting.ravel(), northing_south.ravel(), upward.ravel()
                 )
@@ -406,7 +406,7 @@ class TestSymmetryBn:
         magnetization = np.array(magnetization)
         b_n_east = np.array(
             list(
-                magnetic_n(e, n, u, sample_prism, magnetization)
+                magnetic_n(e, n, u, *sample_prism, *magnetization)
                 for e, n, u in zip(
                     easting_east.ravel(), northing.ravel(), upward.ravel()
                 )
@@ -414,7 +414,7 @@ class TestSymmetryBn:
         )
         b_n_west = np.array(
             list(
-                magnetic_n(e, n, u, sample_prism, magnetization)
+                magnetic_n(e, n, u, *sample_prism, *magnetization)
                 for e, n, u in zip(
                     easting_west.ravel(), northing.ravel(), upward.ravel()
                 )
@@ -444,13 +444,13 @@ class TestSymmetryBn:
         # observation points
         b_n_north = np.array(
             list(
-                magnetic_n(e, n, u, sample_prism, magnetization_north)
+                magnetic_n(e, n, u, *sample_prism, *magnetization_north)
                 for e, n, u in zip(easting, northing, upward)
             )
         )
         b_n_south = np.array(
             list(
-                magnetic_n(e, n, u, sample_prism, magnetization_south)
+                magnetic_n(e, n, u, *sample_prism, *magnetization_south)
                 for e, n, u in zip(easting, northing, upward)
             )
         )
@@ -497,7 +497,7 @@ class TestSymmetryBu:
         magnetization = np.array(magnetization)
         b_u_top = np.array(
             list(
-                magnetic_u(e, n, u, sample_prism, magnetization)
+                magnetic_u(e, n, u, *sample_prism, *magnetization)
                 for e, n, u in zip(
                     easting.ravel(), northing.ravel(), upward_top.ravel()
                 )
@@ -505,7 +505,7 @@ class TestSymmetryBu:
         )
         b_u_bottom = np.array(
             list(
-                magnetic_u(e, n, u, sample_prism, magnetization)
+                magnetic_u(e, n, u, *sample_prism, *magnetization)
                 for e, n, u in zip(
                     easting.ravel(), northing.ravel(), upward_bottom.ravel()
                 )
@@ -549,7 +549,7 @@ class TestSymmetryBu:
         magnetization = np.array(magnetization)
         b_u_north = np.array(
             list(
-                magnetic_u(e, n, u, sample_prism, magnetization)
+                magnetic_u(e, n, u, *sample_prism, *magnetization)
                 for e, n, u in zip(
                     easting.ravel(), northing_north.ravel(), upward.ravel()
                 )
@@ -557,7 +557,7 @@ class TestSymmetryBu:
         )
         b_u_south = np.array(
             list(
-                magnetic_u(e, n, u, sample_prism, magnetization)
+                magnetic_u(e, n, u, *sample_prism, *magnetization)
                 for e, n, u in zip(
                     easting.ravel(), northing_south.ravel(), upward.ravel()
                 )
@@ -601,7 +601,7 @@ class TestSymmetryBu:
         magnetization = np.array(magnetization)
         b_u_east = np.array(
             list(
-                magnetic_u(e, n, u, sample_prism, magnetization)
+                magnetic_u(e, n, u, *sample_prism, *magnetization)
                 for e, n, u in zip(
                     easting_east.ravel(), northing.ravel(), upward.ravel()
                 )
@@ -609,7 +609,7 @@ class TestSymmetryBu:
         )
         b_u_west = np.array(
             list(
-                magnetic_u(e, n, u, sample_prism, magnetization)
+                magnetic_u(e, n, u, *sample_prism, *magnetization)
                 for e, n, u in zip(
                     easting_west.ravel(), northing.ravel(), upward.ravel()
                 )
@@ -639,13 +639,13 @@ class TestSymmetryBu:
         # observation points
         b_u_up = np.array(
             list(
-                magnetic_u(e, n, u, sample_prism, magnetization_up)
+                magnetic_u(e, n, u, *sample_prism, *magnetization_up)
                 for e, n, u in zip(easting, northing, upward)
             )
         )
         b_u_down = np.array(
             list(
-                magnetic_u(e, n, u, sample_prism, magnetization_down)
+                magnetic_u(e, n, u, *sample_prism, *magnetization_down)
                 for e, n, u in zip(easting, northing, upward)
             )
         )
@@ -669,7 +669,7 @@ class TestMagneticField:
         # Compute all components of B using magnetic_field
         b = np.array(
             list(
-                magnetic_field(e, n, u, sample_prism, sample_magnetization)
+                magnetic_field(e, n, u, *sample_prism, *sample_magnetization)
                 for e, n, u in zip(*sample_3d_grid)
             )
         )
@@ -677,19 +677,19 @@ class TestMagneticField:
         # Computed the individual fields
         b_e_expected = np.array(
             list(
-                magnetic_e(e, n, u, sample_prism, sample_magnetization)
+                magnetic_e(e, n, u, *sample_prism, *sample_magnetization)
                 for e, n, u in zip(*sample_3d_grid)
             )
         )
         b_n_expected = np.array(
             list(
-                magnetic_n(e, n, u, sample_prism, sample_magnetization)
+                magnetic_n(e, n, u, *sample_prism, *sample_magnetization)
                 for e, n, u in zip(*sample_3d_grid)
             )
         )
         b_u_expected = np.array(
             list(
-                magnetic_u(e, n, u, sample_prism, sample_magnetization)
+                magnetic_u(e, n, u, *sample_prism, *sample_magnetization)
                 for e, n, u in zip(*sample_3d_grid)
             )
         )
@@ -719,13 +719,13 @@ class TestDivergenceOfB:
         # Compute b_e on original and shifted coordinates
         b_e = np.array(
             list(
-                magnetic_e(e, n, u, prism, magnetization)
+                magnetic_e(e, n, u, *prism, *magnetization)
                 for e, n, u in zip(easting, northing, upward)
             )
         )
         b_e_shifted = np.array(
             list(
-                magnetic_e(e, n, u, prism, magnetization)
+                magnetic_e(e, n, u, *prism, *magnetization)
                 for e, n, u in zip(easting_shifted, northing, upward)
             )
         )
@@ -744,13 +744,13 @@ class TestDivergenceOfB:
         # Compute b_e on original and shifted coordinates
         b_n = np.array(
             list(
-                magnetic_n(e, n, u, prism, magnetization)
+                magnetic_n(e, n, u, *prism, *magnetization)
                 for e, n, u in zip(easting, northing, upward)
             )
         )
         b_n_shifted = np.array(
             list(
-                magnetic_n(e, n, u, prism, magnetization)
+                magnetic_n(e, n, u, *prism, *magnetization)
                 for e, n, u in zip(easting, northing_shifted, upward)
             )
         )
@@ -769,13 +769,13 @@ class TestDivergenceOfB:
         # Compute b_e on original and shifted coordinates
         b_u = np.array(
             list(
-                magnetic_u(e, n, u, prism, magnetization)
+                magnetic_u(e, n, u, *prism, *magnetization)
                 for e, n, u in zip(easting, northing, upward)
             )
         )
         b_u_shifted = np.array(
             list(
-                magnetic_u(e, n, u, prism, magnetization)
+                magnetic_u(e, n, u, *prism, *magnetization)
                 for e, n, u in zip(easting, northing, upward_shifted)
             )
         )
@@ -900,7 +900,7 @@ class TestMagneticFieldSingularities:
         easting, northing, upward = self.get_vertices(sample_prism)
         magnetization = np.array([1.0, 1.0, 1.0])
         results = list(
-            forward_func(e, n, u, sample_prism, magnetization)
+            forward_func(e, n, u, *sample_prism, *magnetization)
             for (e, n, u) in zip(easting, northing, upward)
         )
         assert np.isnan(results).all()
@@ -918,7 +918,7 @@ class TestMagneticFieldSingularities:
         easting, northing, upward = coordinates
         magnetization = np.array([1.0, 1.0, 1.0])
         results = list(
-            forward_func(e, n, u, sample_prism, magnetization)
+            forward_func(e, n, u, *sample_prism, *magnetization)
             for (e, n, u) in zip(easting, northing, upward)
         )
         assert np.isnan(results).all()
@@ -933,7 +933,7 @@ class TestMagneticFieldSingularities:
         easting, northing, upward = self.get_interior_points(sample_prism)
         magnetization = np.array([1.0, 1.0, 1.0])
         results = list(
-            forward_func(e, n, u, sample_prism, magnetization)
+            forward_func(e, n, u, *sample_prism, *magnetization)
             for (e, n, u) in zip(easting, northing, upward)
         )
         assert np.isnan(results).all()
@@ -956,12 +956,12 @@ class TestMagneticFieldSingularities:
             component_mapping = {"easting": 0, "northing": 1, "upward": 2}
             index = component_mapping[direction]
             results = list(
-                forward_func(e, n, u, sample_prism, magnetization)[index]
+                forward_func(e, n, u, *sample_prism, *magnetization)[index]
                 for (e, n, u) in zip(easting, northing, upward)
             )
         else:
             results = list(
-                forward_func(e, n, u, sample_prism, magnetization)
+                forward_func(e, n, u, *sample_prism, *magnetization)
                 for (e, n, u) in zip(easting, northing, upward)
             )
         npt.assert_allclose(results, results[0])

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -144,14 +144,21 @@ a single observation point:
 
    # Define the magnetic moment vector of the dipole (in A m^2)
    mag_moment_e, mag_moment_n, mag_moment_u = 1., 1., -2.
-   magnetic_moment = np.array([mag_moment_e, mag_moment_n, mag_moment_u])
 
    # Define coordinates of an observation point
    easting, northing, upward = -2., 2., 2.
 
    # Compute the magnetic field of the dipole on the observation point (in T)
    b_e, b_n, b_u = choclo.dipole.magnetic_field(
-      easting, northing, upward, easting_d, northing_d, upward_d, magnetic_moment
+      easting,
+      northing,
+      upward,
+      easting_d,
+      northing_d,
+      upward_d,
+      mag_moment_e,
+      mag_moment_n,
+      mag_moment_u,
    )
    print(f"b_e: {b_e:.2e} T")
    print(f"b_n: {b_n:.2e} T")

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,10 @@ ignore =
     E741,
     # Line break before binary operator (conflicts with black)
     W503,
+    # Functions too long. The kernels will end up a bit long but not complex.
+    CFQ001,
+    # Number of argumentys. Kernels take only scalars (no lists or arrays)
+    CFQ002,
 exclude =
     .git,
     __pycache__,
@@ -76,8 +80,3 @@ rst-roles =
     ref,
 # Ignore "Unknown target name" raised on citations
 extend-ignore = RST306
-
-# Configure flake8-functions
-# --------------------------
-# Allow a max of 10 arguments per function
-max-parameters-amount = 10


### PR DESCRIPTION
Choclo functions shouldn't take array inputs because they may require a user to convert their prism, dipole moment, or magnetization format into what Choclo expects with the possible result of reallocating memory or having to iterate over slices in non-optimal ways. Since these functions are meant to be wrapped by other JIT-compiled functions that the user creates, they should be as flexible as possible with their inputs. This means converting the `dipole_moment`, `prism`, and `magnetization` arguments into individual components instead of arrays. The code is now a bit longer because of this but there is no other down side. Had to update some linting rules to account for the longer code and larger number of arguments that this entails. 

<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #49 