### PR TITLE
Update the value of the gravitational constant

### DIFF
--- a/choclo/constants.py
+++ b/choclo/constants.py
@@ -7,7 +7,7 @@
 """
 Define universal constants
 """
-#: Gravitational constant :math:`G` in SI units (:math:`m^3 kg^{-1} s^{-1}`)
+#: Gravitational constant :math:`G` in SI units (:math:`m^3 kg^{-1} s^{-2}`)
 GRAVITATIONAL_CONST = 6.6743e-11
 
 #: Vacuum magnetic permeability :math:`\mu_0` in SI units (:math:`NA^{-2}`)

--- a/choclo/constants.py
+++ b/choclo/constants.py
@@ -8,7 +8,7 @@
 Define universal constants
 """
 #: Gravitational constant :math:`G` in SI units (:math:`m^3 kg^{-1} s^{-1}`)
-GRAVITATIONAL_CONST = 0.00000000006673
+GRAVITATIONAL_CONST = 6.6743e-11
 
 #: Vacuum magnetic permeability :math:`\mu_0` in SI units (:math:`NA^{-2}`)
 VACUUM_MAGNETIC_PERMEABILITY = 1.25663706212e-06


### PR DESCRIPTION
Use the latest standard value (2018), which is the one used by SciPy.

**References**

- https://docs.scipy.org/doc/scipy/reference/constants.html
- https://en.wikipedia.org/wiki/Gravitational_constant#Modern_value
