### PR TITLE
Mention SimPEG collaboration in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 </p>
 
 <p align="center">
-Part of the <a href="https://www.fatiando.org"><strong>Fatiando a Terra</strong></a> project
+Part of the <a href="https://www.fatiando.org"><strong>Fatiando
+a Terra</strong></a> project, built in collaboration with <a
+href="https://simpeg.xyz"><strong>SimPEG</strong></a>
 </p>
 
 <p align="center">

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -138,3 +138,4 @@ of developing a common engine for running gravity and magnetic forward models.
     Code of Conduct <https://github.com/fatiando/choclo/blob/main/CODE_OF_CONDUCT.md>
     Source code on GitHub <https://github.com/fatiando/choclo>
     The Fatiando a Terra project <https://www.fatiando.org>
+    SimPEG <https://simpeg.xyz>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -27,10 +27,17 @@
 kernel functions for running geophysical forward and inverse models, intended
 to be used by other libraries as the underlying layer of their computation.
 
-"Choclo" is a term used in some countries of South America to refer to corn,
-originated from the `quechua
-<https://en.wikipedia.org/wiki/Quechuan_languages>`__
-word *chuqllu*.
+Choclo is part of the `Fatiando a Terra <https://www.fatiando.org/>`__ project,
+and built in collaboration with `SimPEG <https://simpeg.xyz>`__ with the goal
+of developing a common engine for running gravity and magnetic forward models.
+
+.. hint::
+
+   "Choclo" is a term used in some countries of South America to refer to corn,
+   originated from the `quechua
+   <https://en.wikipedia.org/wiki/Quechuan_languages>`__
+   word *chuqllu*.
+
 
 .. grid:: 1 2 1 2
     :margin: 5 5 0 0
@@ -90,11 +97,6 @@ word *chuqllu*.
             :color: primary
             :outline:
             :expand:
-
-.. seealso::
-
-    Choclo is a part of the
-    `Fatiando a Terra <https://www.fatiando.org/>`__ project.
 
 
 .. toctree::

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -12,8 +12,9 @@ modellings, sensitivity matrices calculations, equivalent sources
 implementations and more.
 
 These functions are not designed to be used by final users. Instead they are
-meant to be part of the underlaying engine of a higher level codebase, like
-`Harmonica <https://www.fatiando.org/harmonica>`__.
+meant to be part of the underlying engine of a higher level codebase, like
+`Harmonica <https://www.fatiando.org/harmonica>`__ and `SimPEG
+<https://docs.simpeg.xyz>`__.
 
 All Choclo functions rely on `Numba <https://numba.pydata.org/>`__ for
 just-in-time compilations, meaning that there's no need to distribute


### PR DESCRIPTION
Mention SimPEG collaboration to build Choclo in the docs and in the `README.md`.

**Relevant issues/PRs:**

The motivation to build Choclo raised after @santisoler started collaborating
in SimPEG. The goal is to have a shared engine for running the gravity and
magnetic forward models. Choclo is being included in SimPEG's gravity and
magnetic simulations (see https://github.com/simpeg/simpeg/pull/1285 and
https://github.com/simpeg/simpeg/pull/1321).
