### PR TITLE
Setup Trusted Publisher deployment to PyPI

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -79,6 +79,10 @@ jobs:
     needs: build
     # Only publish from the origin repository, not forks
     if: github.repository_owner == 'fatiando' && github.event_name != 'pull_request'
+    environment: pypi
+    permissions:
+      # This permission allows trusted publishing to PyPI (without an API token)
+      id-token: write
 
     steps:
       - name: Checkout
@@ -98,10 +102,8 @@ jobs:
       - name: Publish to Test PyPI
         # Only publish to TestPyPI when a PR is merged (pushed to main)
         if: success() && github.event_name == 'push'
-        uses: pypa/gh-action-pypi-publish@bce3b74dbf8cc32833ffba9d15f83425c1a736e0
+        uses: pypa/gh-action-pypi-publish@v1.8.12
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
           # Allow existing releases on test PyPI without errors.
           # NOT TO BE USED in PyPI!
@@ -110,7 +112,4 @@ jobs:
       - name: Publish to PyPI
         # Only publish to PyPI when a release triggers the build
         if: success() && github.event_name == 'release'
-        uses: pypa/gh-action-pypi-publish@bce3b74dbf8cc32833ffba9d15f83425c1a736e0
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@v1.8.12

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install requirements
         run: python -m pip install -r env/requirements-build.txt
@@ -68,8 +68,8 @@ jobs:
       # Store the archives as a build artifact so we can deploy them later
       - name: Upload archives as artifacts
         # Only if not a pull request
-        #if: success() && github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v2
+        if: success() && github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
         with:
           name: pypi-${{ github.sha }}
           path: dist
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     # Only publish from the origin repository, not forks
-    if: github.repository_owner == 'fatiando' #&& github.event_name != 'pull_request'
+    if: github.repository_owner == 'fatiando' && github.event_name != 'pull_request'
     environment: pypi
     permissions:
       # This permission allows trusted publishing to PyPI (without an API token)
@@ -94,14 +94,14 @@ jobs:
 
       # Fetch the built archives from the "build" job
       - name: Download built archives artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: pypi-${{ github.sha }}
           path: dist
 
       - name: Publish to Test PyPI
         # Only publish to TestPyPI when a PR is merged (pushed to main)
-        #if: success() && github.event_name == 'push'
+        if: success() && github.event_name == 'push'
         uses: pypa/gh-action-pypi-publish@v1.8.12
         with:
           repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -68,7 +68,7 @@ jobs:
       # Store the archives as a build artifact so we can deploy them later
       - name: Upload archives as artifacts
         # Only if not a pull request
-        if: success() && github.event_name != 'pull_request'
+        #if: success() && github.event_name != 'pull_request'
         uses: actions/upload-artifact@v2
         with:
           name: pypi-${{ github.sha }}
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     # Only publish from the origin repository, not forks
-    if: github.repository_owner == 'fatiando' && github.event_name != 'pull_request'
+    if: github.repository_owner == 'fatiando' #&& github.event_name != 'pull_request'
     environment: pypi
     permissions:
       # This permission allows trusted publishing to PyPI (without an API token)
@@ -101,7 +101,7 @@ jobs:
 
       - name: Publish to Test PyPI
         # Only publish to TestPyPI when a PR is merged (pushed to main)
-        if: success() && github.event_name == 'push'
+        #if: success() && github.event_name == 'push'
         uses: pypa/gh-action-pypi-publish@v1.8.12
         with:
           repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Use this instead of the API tokens we used before. It's safer and easier to use because it doesn't required generating tokens and pasting them to GitHub.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to https://github.com/fatiando/community/issues/141