### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python: ["3.7", "3.10"]
+        python: ["3.8", "3.10"]
         include:
-          - python: "3.7"
+          - python: "3.8"
             dependencies: oldest
           - python: "3.10"
             dependencies: latest

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -6,7 +6,7 @@ Installing
 Which Python?
 -------------
 
-You'll need **Python 3.7 or greater**.
+You'll need **Python 3.8 or greater**.
 See :ref:`python-versions` if you require support for older versions.
 
 We recommend using the

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ classifiers =
     Topic :: Scientific/Engineering
     Topic :: Software Development :: Libraries
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -37,7 +36,7 @@ project_urls =
 [options]
 zip_safe = True
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     numpy>=1.19
     numba>=0.52


### PR DESCRIPTION
Drop support for Python 3.7, which had an EOL by June 2023.
