### PR TITLE
Extend support for Python 3.12

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REQUIREMENTS: env/requirements-docs.txt env/requirements-build.txt
-      PYTHON: "3.13"
+      PYTHON: "3.12"
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REQUIREMENTS: env/requirements-docs.txt env/requirements-build.txt
-      PYTHON: "3.11"
+      PYTHON: "3.13"
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install requirements
         run: python -m pip install -r env/requirements-build.txt

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install requirements
         run: python -m pip install -r env/requirements-style.txt
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install requirements
         run: python -m pip install -r env/requirements-style.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,11 +38,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python: ["3.7", "3.10"]
+        python: ["3.7", "3.12"]
         include:
           - python: "3.7"
             dependencies: oldest
-          - python: "3.10"
+          - python: "3.12"
             dependencies: latest
     env:
       REQUIREMENTS: env/requirements-build.txt env/requirements-test.txt

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: choclo
 channels:
   - conda-forge
 dependencies:
-  - python==3.11
+  - python==3.12
   - pip
   - make
   # Run

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,8 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 url = https://github.com/fatiando/choclo
 project_urls =
     Documentation = https://www.fatiando.org/choclo


### PR DESCRIPTION
Extend Choclo support for Python 3.12. Update classifiers in `setup.cfg`, run tests using Python 3.12 in CI, bump Python version in `environment.yml`.
