### PR TITLE
Add changelog for v0.2.0

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -3,6 +3,53 @@
 Changelog
 =========
 
+Version 0.2.0
+-------------
+
+Released on: 2024/04/09
+
+doi: https://doi.org/10.5281/zenodo.10951580
+
+New features:
+
+* Restore kernel functions for forward modelling of point sources (`#58
+  <https://github.com/fatiando/choclo/pull/58>`__)
+
+Documentation:
+
+* Update the versions of Sphinx and its plugins, including dark theme and minor
+  changes to the style of the docs (`#64
+  <https://github.com/fatiando/choclo/pull/64>`__)
+* Mention SimPEG's support and collaboration in docs (`#65
+  <https://github.com/fatiando/choclo/pull/65>`__)
+
+Maintenance:
+
+* Use pip instead of conda for the docs workflow (`#63
+  <https://github.com/fatiando/choclo/pull/63>`__)
+* Use Burocrata to check/add license notices (`#66
+  <https://github.com/fatiando/choclo/pull/66>`__)
+* Use Dependabot to manage GitHub Actions updates (`#68
+  <https://github.com/fatiando/choclo/pull/68>`__)
+* Setup Trusted Publisher deployment to PyPI (`#67
+  <https://github.com/fatiando/choclo/pull/67>`__)
+* Ditch setup.cfg and replace it with pyproject.toml (`#77
+  <https://github.com/fatiando/choclo/pull/77>`__)
+* Replace `_version_generated.py` for `_version.py` (`#80
+  <https://github.com/fatiando/choclo/pull/80>`__)
+* Extend support for Python 3.12 (`#79
+  <https://github.com/fatiando/choclo/pull/79>`__)
+* Drop support for Python 3.7 (`#78
+  <https://github.com/fatiando/choclo/pull/78>`__)
+* Update Black formatting to version 24.2 (`#61
+  <https://github.com/fatiando/choclo/pull/61>`__)
+
+This release contains contributions from:
+
+* Santiago Soler
+* Leonardo Uieda
+
+
 Version 0.1.0
 -------------
 

--- a/doc/versions.rst
+++ b/doc/versions.rst
@@ -7,6 +7,7 @@ Use the links below to access documentation for specific versions
 * `Latest release <https://www.fatiando.org/choclo/latest>`__
 * `Development <https://www.fatiando.org/choclo/dev>`__
   (reflects the current development branch on GitHub)
+* `v0.2.0 <https://www.fatiando.org/choclo/v0.2.0>`__
 * `v0.1.0 <https://www.fatiando.org/choclo/v0.1.0>`__
 * `v0.0.1 <https://www.fatiando.org/choclo/v0.0.1>`__
 


### PR DESCRIPTION
Add changelog to documentation. Add link to the docs for Choclo v0.2.0 in `doc/versions.py`
