### PR TITLE
Run tests with oldest dependencies on x86 macos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,19 +31,28 @@ jobs:
   # Run tests and upload to codecov
   test:
     name: ${{ matrix.os }} python=${{ matrix.python }} dependencies=${{ matrix.dependencies }}
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       # Otherwise, the workflow would stop if a single job fails. We want to
       # run all of them to catch failures in different combinations.
       fail-fast: false
       matrix:
-        os: [ubuntu, macos, windows]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python: ["3.8", "3.12"]
         include:
           - python: "3.8"
             dependencies: oldest
           - python: "3.12"
             dependencies: latest
+          # test on macos-13 (x86) using oldest dependencies and python 3.8
+          - os: macos-13
+            dependencies: oldest
+            python: "3.8"
+        exclude:
+          # don't test on macos-latest (arm64) with oldest dependencies
+          - os: macos-latest
+            python: "3.8"
+
     env:
       REQUIREMENTS: env/requirements-build.txt env/requirements-test.txt
       # Used to tag codecov submissions


### PR DESCRIPTION
Change configuration of tests in GitHub Actions: use the latest x86 macos runner with the `oldest` dependencies and Python 3.8. Use the latest macos runner (arm64) only against the `latest` requirements. This fixes CI failing because there are not Numpy binaries in PyPI for arm64 and compatible with Python 3.8.
