### PR TITLE
Fix style errors in docstrings

### DIFF
--- a/choclo/prism/_gravity.py
+++ b/choclo/prism/_gravity.py
@@ -72,7 +72,7 @@ def gravity_pot(
         The bottom boundary of the prism. Must be in meters.
     prism_top : float
         The top boundary of the prism. Must be in meters.
-    density: float
+    density : float
         Density of the rectangular prism in kilograms per cubic meter.
 
     Returns
@@ -218,7 +218,7 @@ def gravity_e(
         The bottom boundary of the prism. Must be in meters.
     prism_top : float
         The top boundary of the prism. Must be in meters.
-    density: float
+    density : float
         Density of the rectangular prism in kilograms per cubic meter.
 
     Returns
@@ -365,7 +365,7 @@ def gravity_n(
         The bottom boundary of the prism. Must be in meters.
     prism_top : float
         The top boundary of the prism. Must be in meters.
-    density: float
+    density : float
         Density of the rectangular prism in kilograms per cubic meter.
 
     Returns
@@ -512,7 +512,7 @@ def gravity_u(
         The bottom boundary of the prism. Must be in meters.
     prism_top : float
         The top boundary of the prism. Must be in meters.
-    density: float
+    density : float
         Density of the rectangular prism in kilograms per cubic meter.
 
     Returns
@@ -665,7 +665,7 @@ def gravity_ee(
         The bottom boundary of the prism. Must be in meters.
     prism_top : float
         The top boundary of the prism. Must be in meters.
-    density: float
+    density : float
         Density of the rectangular prism in kilograms per cubic meter.
 
     Returns
@@ -836,7 +836,7 @@ def gravity_nn(
         The bottom boundary of the prism. Must be in meters.
     prism_top : float
         The top boundary of the prism. Must be in meters.
-    density: float
+    density : float
         Density of the rectangular prism in kilograms per cubic meter.
 
     Returns
@@ -1007,7 +1007,7 @@ def gravity_uu(
         The bottom boundary of the prism. Must be in meters.
     prism_top : float
         The top boundary of the prism. Must be in meters.
-    density: float
+    density : float
         Density of the rectangular prism in kilograms per cubic meter.
 
     Returns
@@ -1178,7 +1178,7 @@ def gravity_en(
         The bottom boundary of the prism. Must be in meters.
     prism_top : float
         The top boundary of the prism. Must be in meters.
-    density: float
+    density : float
         Density of the rectangular prism in kilograms per cubic meter.
 
     Returns
@@ -1325,7 +1325,7 @@ def gravity_eu(
         The bottom boundary of the prism. Must be in meters.
     prism_top : float
         The top boundary of the prism. Must be in meters.
-    density: float
+    density : float
         Density of the rectangular prism in kilograms per cubic meter.
 
     Returns
@@ -1473,7 +1473,7 @@ def gravity_nu(
         The bottom boundary of the prism. Must be in meters.
     prism_top : float
         The top boundary of the prism. Must be in meters.
-    density: float
+    density : float
         Density of the rectangular prism in kilograms per cubic meter.
 
     Returns

--- a/choclo/prism/_kernels.py
+++ b/choclo/prism/_kernels.py
@@ -366,7 +366,6 @@ def kernel_u(easting, northing, upward, radius):
         by [Nagy2000]_ in order to compute the numerical kernel for the
         **upward** component instead for the downward one.
 
-
     References
     ----------
     - [Nagy2000]_

--- a/choclo/prism/_magnetic.py
+++ b/choclo/prism/_magnetic.py
@@ -214,7 +214,7 @@ def magnetic_field(
     - [Nagy2002]_
     - [Fukushima2020]_
 
-    See also
+    See Also
     --------
     :func:`choclo.prism.magnetic_e`
     :func:`choclo.prism.magnetic_n`
@@ -462,7 +462,7 @@ def magnetic_e(
     - [Nagy2002]_
     - [Fukushima2020]_
 
-    See also
+    See Also
     --------
     :func:`choclo.prism.magnetic_field`
     :func:`choclo.prism.magnetic_n`
@@ -663,7 +663,7 @@ def magnetic_n(
     - [Nagy2002]_
     - [Fukushima2020]_
 
-    See also
+    See Also
     --------
     :func:`choclo.prism.magnetic_field`
     :func:`choclo.prism.magnetic_e`
@@ -864,7 +864,7 @@ def magnetic_u(
     - [Nagy2002]_
     - [Fukushima2020]_
 
-    See also
+    See Also
     --------
     :func:`choclo.prism.magnetic_field`
     :func:`choclo.prism.magnetic_e`

--- a/choclo/prism/_magnetic.py
+++ b/choclo/prism/_magnetic.py
@@ -205,7 +205,6 @@ def magnetic_field(
 
         \mathbf{B}(\mathbf{p}) = \frac{\mu_0}{4\pi} \mathbf{U} \cdot \mathbf{M}
 
-
     References
     ----------
     - [Blakely1995]_


### PR DESCRIPTION
Fix style for `density` argument in prism functions. Capitalize See Also sections in prism functions. Remove double empty lines in docstrings.