### PR TITLE
Add target to validate docstrings with numpydoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ help:
 	@echo "  check     run code style and quality checks"
 	@echo "  build     build source and wheel distributions"
 	@echo "  clean     clean up build and generated files"
+	@echo "  numpydoc  validate docstrings using numpydoc"
 	@echo ""
 
 build:
@@ -51,6 +52,10 @@ check-format:
 
 check-style:
 	flake8 $(CHECK_STYLE)
+
+numpydoc:
+	# With numpydoc>=1.8.0 this line could be replaced by `numpydoc lint`
+	python -m numpydoc.hooks.validate_docstrings $(wildcard ${PROJECT}/**/*.py)
 
 clean:
 	find . -name "*.pyc" -exec rm -v {} \;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,20 @@ notice = '''
 #
 # This code is part of the Fatiando a Terra project (https://www.fatiando.org)
 #'''
+
+# Validate docstrings using numpydoc
+[tool.numpydoc_validation]
+checks = [
+    "all",   # report on all checks, except the below
+    "EX01",
+    "SA01",
+    "SS03",
+    "RT02",
+    "ES01",  # no extended summary
+]
+exclude = [  # don't report on objects that match any of these regex
+    '\.undocumented_method$',
+    '\.__repr__$',
+    '_version',
+    'test_[a-z_]*', # exclude all tests
+]


### PR DESCRIPTION
Add new target to the Makefile to validate docstrings using `numpydoc`. Add rules for validating docstrings using `numpydoc` to `pyproject.toml`.

<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file
in this repository (if available) and the general guidelines at
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged.
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
