### PR TITLE
Update how output variables are stored in Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Get the pip cache folder
         id: pip-cache
         run: |
-          run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: Setup caching for pip packages
         uses: actions/cache@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Get the pip cache folder
         id: pip-cache
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: Setup caching for pip packages
         uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Get the pip cache folder
         id: pip-cache
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: Setup caching for pip packages
         uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Get the pip cache folder
         id: pip-cache
         run: |
-          run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: Setup caching for pip packages
         uses: actions/cache@v4


### PR DESCRIPTION
Replace the deprecated `set-output` in GitHub Actions for concatenating name and values into the `GITHUB_OUTPUT` env variable.

Reference: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
