### PR TITLE
Replace `build` for `python-build` in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - numpy
   - numba
   # Build
-  - build
+  - python-build
   - twine
   # Test
   - pytest


### PR DESCRIPTION
The `build` package in `conda-forge` is outdated, `python-build` should be used instead.
