### PR TITLE
Use zizmor to lint GitHub Actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -33,3 +33,6 @@ jobs:
 
       - name: Lint GitHub Actions
         run: make check-actions
+        env:
+          # Set GH_TOKEN to allow zizmor to check online vulnerabilities
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -32,4 +32,4 @@ jobs:
         run: python -m pip freeze
 
       - name: Lint GitHub Actions
-        run: make lint-actions
+        run: make check-actions

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,35 @@
+# Lint GitHub Actions for common security issues using zizmor.
+# Docs: https://woodruffw.github.io/zizmor
+
+name: lint-actions
+
+# Only run on PRs and the main branch.
+# Pushes to branches will only trigger a run when a PR is opened.
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install requirements
+        run: python -m pip install -r env/requirements-style.txt
+
+      - name: List installed packages
+        run: python -m pip freeze
+
+      - name: Lint GitHub Actions
+        run: make lint-actions

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -183,7 +183,7 @@ jobs:
           echo -e "\nRemoving old files from previous builds of ${version}:"
           rm -rvf "${version}"
           echo -e "\nCopying HTML files to ${version}:"
-          cp -Rvf ../doc/_build/html/ "${version}"/
+          cp -Rvf ../doc/_build/html/ "${version}/"
 
           # If this is a new release, update the link from /latest to it
           if [[ "${version}" != "dev" ]]; then

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -174,7 +174,7 @@ jobs:
           # to get the right commit hash.
           message="Deploy $version from $(git rev-parse --short HEAD)"
 
-          cd deploy || exit
+          cd deploy || exit 1
 
           # Need to have this file so that Github doesn't try to run Jekyll
           touch .nojekyll

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -163,10 +163,10 @@ jobs:
         run: |
           # Detect if this is a release or from the main branch
           if [[ "${{ github.event_name }}" == "release" ]]; then
-              # Get the tag name without the "refs/tags/" part
-              version="${GITHUB_REF#refs/*/}"
+            # Get the tag name without the "refs/tags/" part
+            version="${GITHUB_REF#refs/*/}"
           else
-              version=dev
+            version=dev
           fi
           echo "Deploying version: $version"
 
@@ -174,22 +174,22 @@ jobs:
           # to get the right commit hash.
           message="Deploy $version from $(git rev-parse --short HEAD)"
 
-          cd deploy
+          cd deploy || exit
 
           # Need to have this file so that Github doesn't try to run Jekyll
           touch .nojekyll
 
           # Delete all the files and replace with our new  set
           echo -e "\nRemoving old files from previous builds of ${version}:"
-          rm -rvf ${version}
+          rm -rvf "${version}"
           echo -e "\nCopying HTML files to ${version}:"
-          cp -Rvf ../doc/_build/html/ ${version}/
+          cp -Rvf ../doc/_build/html/ "${version}"/
 
           # If this is a new release, update the link from /latest to it
           if [[ "${version}" != "dev" ]]; then
-              echo -e "\nSetup link from ${version} to 'latest'."
-              rm -f latest
-              ln -sf ${version} latest
+            echo -e "\nSetup link from ${version} to 'latest'."
+            rm -f latest
+            ln -sf "${version}" latest
           fi
 
           # Stage the commit
@@ -204,17 +204,17 @@ jobs:
           # If this is a dev build and the last commit was from a dev build
           # (detect if "dev" was in the previous commit message), reuse the
           # same commit
-          if [[ "${version}" == "dev" && `git log -1 --format='%s'` == *"dev"* ]]; then
-              echo -e "\nAmending last commit:"
-              git commit --amend --reset-author -m "$message"
+          if [[ "${version}" == "dev" && $(git log -1 --format='%s') == *"dev"* ]]; then
+            echo -e "\nAmending last commit:"
+            git commit --amend --reset-author -m "$message"
           else
-              echo -e "\nMaking a new commit:"
-              git commit -m "$message"
+            echo -e "\nMaking a new commit:"
+            git commit -m "$message"
           fi
 
           # Make the push quiet just in case there is anything that could leak
           # sensitive information.
           echo -e "\nPushing changes to gh-pages."
-          git push -fq origin gh-pages 2>&1 >/dev/null
+          { git push -fq origin gh-pages > /dev/null; } 2>&1
 
           echo -e "\nFinished uploading generated files."

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -135,6 +135,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # The GitHub token is preserved by default but this job doesn't need
+          # to be able to push to GitHub.
+          persist-credentials: false
 
       # Fetch the built docs from the "build" job
       - name: Download HTML documentation artifact
@@ -151,6 +155,9 @@ jobs:
           path: deploy
           # Download the entire history
           fetch-depth: 0
+          # The GitHub token is preserved by default but this job doesn't need
+          # to be able to push to GitHub.
+          persist-credentials: false
 
       - name: Push the built HTML to gh-pages
         run: |

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ TESTDIR=tmp-test-dir-with-unique-name
 PYTEST_ARGS=--cov-config=../.coveragerc --cov-report=term-missing --cov=$(PROJECT) --doctest-modules -v --pyargs
 NUMBATEST_ARGS=--doctest-modules -v --pyargs
 CHECK_STYLE=$(PROJECT) doc
+GITHUB_ACTIONS=.github/workflows
+
+.PHONY: build install test test_coverage test_numba format check check-format check_style check-actions clean
 
 help:
 	@echo "Commands:"
@@ -42,7 +45,7 @@ format:
 	black $(CHECK_STYLE)
 	burocrata --extension=py $(CHECK_STYLE)
 
-check: check-format check-style
+check: check-format check-style check-actions
 
 check-format:
 	isort --check $(CHECK_STYLE)
@@ -51,6 +54,9 @@ check-format:
 
 check-style:
 	flake8 $(CHECK_STYLE)
+
+check-actions:
+	zizmor $(GITHUB_ACTIONS)
 
 clean:
 	find . -name "*.pyc" -exec rm -v {} \;

--- a/env/requirements-style.txt
+++ b/env/requirements-style.txt
@@ -11,3 +11,4 @@ flake8-simplify
 flake8-unused-arguments
 pep8-naming
 burocrata
+zizmor

--- a/environment.yml
+++ b/environment.yml
@@ -38,3 +38,4 @@ dependencies:
   - pep8-naming
   - pip:
     - burocrata
+    - zizmor


### PR DESCRIPTION
Make use of `zizmor` to lint GitHub Actions workflows and catch potential security issues. Add `zizmor` to the `environment.yml` and to the `requirements-style.txt`. Add a new `check-actions` target in the `Makefile` that runs `zizmor` on every workflow. Add a new workflow for running `zizmor` on PRs and on pushes to `main`. Apply some minor changes to the script that deploys docs to GitHub Pages after suggestions obtained by running `shellcheck` on it.

**Relevant issues/PRs:**

Part of fatiando/community#159
