### PR TITLE
Fix bug in third order prism kernels

### DIFF
--- a/choclo/prism/_kernels.py
+++ b/choclo/prism/_kernels.py
@@ -1502,5 +1502,4 @@ def _kernel_iij(x_i, x_j, x_k, radius):
         return np.nan
     if x_i == 0 and x_j == 0:
         return 0.0
-    return -x_i / ((x_k + radius) * radius)
-    # return x_i * x_k / ((x_i**2 + x_j**2) * radius)
+    return x_i * x_k / ((x_i**2 + x_j**2) * radius)

--- a/choclo/prism/_kernels.py
+++ b/choclo/prism/_kernels.py
@@ -1503,3 +1503,4 @@ def _kernel_iij(x_i, x_j, x_k, radius):
     if x_i == 0 and x_j == 0:
         return 0.0
     return -x_i / ((x_k + radius) * radius)
+    # return x_i * x_k / ((x_i**2 + x_j**2) * radius)

--- a/choclo/prism/_kernels.py
+++ b/choclo/prism/_kernels.py
@@ -1055,9 +1055,9 @@ def kernel_een(easting, northing, upward, radius):
 
         k_{xxy}(x, y, z) =
             \frac{
-                - x
+                x z
             }{
-                (z + \sqrt{x^2 + y^2 + z^2})
+                (x^2 + y^2)
                 \sqrt{x^2 + y^2 + z^2}
             }
 
@@ -1066,7 +1066,7 @@ def kernel_een(easting, northing, upward, radius):
     >>> x, y, z = 3.1, 5.2, -3.0
     >>> r = np.sqrt(x**2 + y**2 + z**2)
     >>> float(kernel_een(x, y, z, r)) # doctest: +NUMBER
-    -0.12214070
+    -0.03755680
     """
     return _kernel_iij(easting, northing, upward, radius)
 
@@ -1108,9 +1108,9 @@ def kernel_eeu(easting, northing, upward, radius):
 
         k_{xxz}(x, y, z) =
             \frac{
-                - x
+                x y
             }{
-                (y + \sqrt{x^2 + y^2 + z^2})
+                (x^2 + z^2)
                 \sqrt{x^2 + y^2 + z^2}
             }
 
@@ -1119,7 +1119,7 @@ def kernel_eeu(easting, northing, upward, radius):
     >>> x, y, z = 3.1, 5.2, -3.0
     >>> r = np.sqrt(x**2 + y**2 + z**2)
     >>> float(kernel_eeu(x, y, z, r)) # doctest: +NUMBER
-    -0.03837408
+    0.128203025
     """
     return _kernel_iij(easting, upward, northing, radius)
 
@@ -1161,9 +1161,9 @@ def kernel_enn(easting, northing, upward, radius):
 
         k_{xyy}(x, y, z) =
             \frac{
-                - y
+                y z
             }{
-                (z + \sqrt{x^2 + y^2 + z^2})
+                (x^2 + y^2)
                 \sqrt{x^2 + y^2 + z^2}
             }
 
@@ -1172,7 +1172,7 @@ def kernel_enn(easting, northing, upward, radius):
     >>> x, y, z = 3.1, 5.2, -3.0
     >>> r = np.sqrt(x**2 + y**2 + z**2)
     >>> float(kernel_enn(x, y, z, r)) # doctest: +NUMBER
-    -0.20488118
+    -0.06299850
     """
     return _kernel_iij(northing, easting, upward, radius)
 
@@ -1214,9 +1214,9 @@ def kernel_nnu(easting, northing, upward, radius):
 
         k_{yyz}(x, y, z) =
             \frac{
-                - y
+                x y
             }{
-                (x + \sqrt{x^2 + y^2 + z^2})
+                (y^2 + z^2)
                 \sqrt{x^2 + y^2 + z^2}
             }
 
@@ -1225,7 +1225,7 @@ def kernel_nnu(easting, northing, upward, radius):
     >>> x, y, z = 3.1, 5.2, -3.0
     >>> r = np.sqrt(x**2 + y**2 + z**2)
     >>> float(kernel_nnu(x, y, z, r)) # doctest: +NUMBER
-    -0.07808384
+    0.066200286
     """
     return _kernel_iij(northing, upward, easting, radius)
 
@@ -1267,9 +1267,9 @@ def kernel_euu(easting, northing, upward, radius):
 
         k_{xzz}(x, y, z) =
             \frac{
-                - z
+                y z
             }{
-                (y + \sqrt{x^2 + y^2 + z^2})
+                (x^2 + z^2)
                 \sqrt{x^2 + y^2 + z^2}
             }
 
@@ -1278,7 +1278,7 @@ def kernel_euu(easting, northing, upward, radius):
     >>> x, y, z = 3.1, 5.2, -3.0
     >>> r = np.sqrt(x**2 + y**2 + z**2)
     >>> float(kernel_euu(x, y, z, r)) # doctest: +NUMBER
-    0.03713621
+    -0.12406744
     """
     return _kernel_iij(upward, easting, northing, radius)
 
@@ -1320,9 +1320,9 @@ def kernel_nuu(easting, northing, upward, radius):
 
         k_{yzz}(x, y, z) =
             \frac{
-                - z
+                x z
             }{
-                (x + \sqrt{x^2 + y^2 + z^2})
+                (y^2 + z^2)
                 \sqrt{x^2 + y^2 + z^2}
             }
 
@@ -1331,7 +1331,7 @@ def kernel_nuu(easting, northing, upward, radius):
     >>> x, y, z = 3.1, 5.2, -3.0
     >>> r = np.sqrt(x**2 + y**2 + z**2)
     >>> float(kernel_nuu(x, y, z, r)) # doctest: +NUMBER
-    0.04504837
+    -0.03819247
     """
     return _kernel_iij(upward, northing, easting, radius)
 
@@ -1456,9 +1456,9 @@ def _kernel_iij(x_i, x_j, x_k, radius):
 
         k_{iij}(x_i, x_j, x_k) =
             \frac{
-                - x_i
+                x_i x_k
             }{
-                (x_k + \sqrt{x_i^2 + x_j^2 + x_k^2})
+                (x_i^2 + x_j^2)
                 \sqrt{x_i^2 + x_j^2 + x_k^2}
             }
 

--- a/choclo/tests/test_prism_kernels.py
+++ b/choclo/tests/test_prism_kernels.py
@@ -74,3 +74,47 @@ class TestThirdOrderKernelsOnVertex:
         radius = 0.0
         result = kernel(easting, northing, upward, radius)
         assert np.isnan(result)
+
+
+class TestKerneliij:
+    """
+    Test ``kernel_iij`` for numerical instabilities.
+
+    The previous implementation of ``kernel_iij`` suffered from numerical
+    instabilities when x_i and x_j are close to zero and x_k is negative:
+    adding the radius with x_k might lead to high float precision errors.
+    In the special case where radius is exactly equal to x_k (up to float point
+    precision, but x_i or x_j are not zero, it will lead to a division by zero
+    error.
+    """
+
+    def test_kernel_iij_division_by_zero(self):
+        """
+        Test if we don't get division by zero.
+
+        Evaluate ``kernel_iij`` on ``x > 0``, ``y=0``, ``z < 0`` and
+        ``x << |z|``. If we use the previous implementation of kernel_iij, this
+        test should fail.
+        """
+        x, y, z = 1e-12, 0, -500_000
+        radius = np.sqrt(x**2 + y**2 + z**2)
+        kernel_een(x, y, z, radius)
+
+    def test_instabilities(self):
+        """
+        Test numerical instabilities on ``kernel_iij``.
+
+        Let's evaluate the kernel_iij on a set of shifted coordinates:
+
+        - ``x``: values around zero, small enough to trigger potential
+          floating point errors with the other coordinates.
+        - ``y``: equal to zero.
+        - ``z``: constant negative value, significantly greater than ``x`` to
+          trigger trigger floating point errors.
+
+        Computing the difference between
+        The kernel_iij for these points should behave as a monotonic decreasing
+        function with x.
+        """
+        delta =
+        x = np.linspace(-1e4, 1e4)


### PR DESCRIPTION
Fix bug related to numerical instabilities on third order kernels `kernel_iij`, where `i, j in {x, y, z}`. Make use of the alternative definition of the kernels. These two different definition are not mathematically equal, but their difference depends solely on two of the three coordinates, therefore when evaluating the kernels on the prism boundaries that extra term gets cancelled out. This property makes these two different definitions equivalent in the purpose of forward modelling prism fields. Add tests that catch the bug and ensure that the new implementation works as expected. Update the docstrings.

**Relevant issues/PRs:**

The bug was reported by @AmziJeffs in https://github.com/simpeg/simpeg/issues/1607
