### PR TITLE
Remove caching of ensaio files: we don't use them in Choclo

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -147,9 +147,9 @@ jobs:
           path: deploy
           # Download the entire history
           fetch-depth: 0
-          # The GitHub token is preserved by default but this job doesn't need
-          # to be able to push to GitHub.
-          persist-credentials: false
+          # We need to explicitly preserve the credentials for the GitHub token
+          # on this branch so we can push to it.
+          persist-credentials: true
 
       - name: Push the built HTML to gh-pages
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ defaults:
     # https://github.com/actions/setup-python/issues/132
     shell: bash -l {0}
 
-permissions: {}
+# permissions: {}
 
 jobs:
   #############################################################################

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -122,7 +122,7 @@ jobs:
     needs: build
     permissions:
       contents: write
-    if: github.event_name == 'release' || github.event_name == 'push'
+    # if: github.event_name == 'release' || github.event_name == 'push'
 
     steps:
       - name: Checkout

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -153,6 +153,8 @@ jobs:
 
       - name: Push the built HTML to gh-pages
         run: |
+          # Exit if any command exits with a non-zero status
+          set -e
           # Detect if this is a release or from the main branch
           if [[ "${{ github.event_name }}" == "release" ]]; then
             # Get the tag name without the "refs/tags/" part

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -105,20 +105,8 @@ jobs:
       - name: Install the package
         run: python -m pip install --no-deps dist/*.whl
 
-      - name: Cache the Ensaio datasets
-        uses: actions/cache@v4
-        with:
-          path: ${{ runner.temp }}/cache/ensaio
-          # Use a constant key to reuse the datasets across all jobs
-          key: ensaio
-
       - name: Build the documentation
         run: make -C doc clean all
-        env:
-          # Fetch the data from the GitHub releases to avoid overloading Zenodo
-          ENSAIO_DATA_FROM_GITHUB: true
-          # Define directory where sample data will be stored
-          ENSAIO_DATA_DIR: ${{ runner.temp }}/cache/ensaio/
 
       # Store the docs as a build artifact so we can deploy it later
       - name: Upload HTML documentation as an artifact


### PR DESCRIPTION
Remove caching of Ensaio files in `docs.yml`: Choclo doesn't use Ensaio for
downloading datasets while building the docs.

<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file
in this repository (if available) and the general guidelines at
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged.
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
