### PR TITLE
Fallback to old line to push changes to gh-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -219,6 +219,5 @@ jobs:
           # Make the push quiet just in case there is anything that could leak
           # sensitive information.
           echo -e "\nPushing changes to gh-pages."
-          { git push -fq origin gh-pages > /dev/null; } 2>&1
-
+          git push -fq origin gh-pages 2>&1 >/dev/null
           echo -e "\nFinished uploading generated files."


### PR DESCRIPTION
Try to fix the deployment of docs by falling back to the old line for pushing changes to gh-pages.
