### PR TITLE
Fix deployment of docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -159,12 +159,14 @@ jobs:
           path: deploy
           # Download the entire history
           fetch-depth: 0
-          # The GitHub token is preserved by default but this job doesn't need
-          # to be able to push to GitHub.
-          persist-credentials: false
+          # We need to explicitly preserve the credentials for the GitHub token
+          # on this branch so we can push to it.
+          persist-credentials: true
 
       - name: Push the built HTML to gh-pages
         run: |
+          # Exit if any command exits with a non-zero status
+          set -e
           # Detect if this is a release or from the main branch
           if [[ "${{ github.event_name }}" == "release" ]]; then
             # Get the tag name without the "refs/tags/" part

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -105,20 +105,8 @@ jobs:
       - name: Install the package
         run: python -m pip install --no-deps dist/*.whl
 
-      - name: Cache the Ensaio datasets
-        uses: actions/cache@v4
-        with:
-          path: ${{ runner.temp }}/cache/ensaio
-          # Use a constant key to reuse the datasets across all jobs
-          key: ensaio
-
       - name: Build the documentation
         run: make -C doc clean all
-        env:
-          # Fetch the data from the GitHub releases to avoid overloading Zenodo
-          ENSAIO_DATA_FROM_GITHUB: true
-          # Define directory where sample data will be stored
-          ENSAIO_DATA_DIR: ${{ runner.temp }}/cache/ensaio/
 
       # Store the docs as a build artifact so we can deploy it later
       - name: Upload HTML documentation as an artifact


### PR DESCRIPTION
Persist credentials after checking out the `gh-pages` in the documentation workflow: we need those credentials to be able to push changes to the `gh-pages` branch. Use `set -e` in the deployment script so the workflow is marked as failed if any command exists with non-zero status. Remove Ensaio caching from workflow, since Choclo doesn't use Ensaio for building docs, so we don't need to cache Ensaio files.


**Relevant issues/PRs:**

Solve what #121 was trying to solve.
