### PR TITLE
Use `-e` option globally in `docs.yml`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,8 @@ defaults:
     # The -l {0} is necessary for conda environments to be activated
     # But this breaks on MacOS if using actions/setup-python:
     # https://github.com/actions/setup-python/issues/132
-    shell: bash -l {0}
+    # -e makes sure builds fail if any command fails
+    shell: bash -e -l {0}
 
 permissions: {}
 
@@ -153,8 +154,6 @@ jobs:
 
       - name: Push the built HTML to gh-pages
         run: |
-          # Exit if any command exits with a non-zero status
-          set -e
           # Detect if this is a release or from the main branch
           if [[ "${{ github.event_name }}" == "release" ]]; then
             # Get the tag name without the "refs/tags/" part


### PR DESCRIPTION
Instead of manually setting `-e` in the deployment script, make bash to run with the `-e` option enabled in the entire workflow, following what GitHub does by default.

**Relevant issues/PRs:**

Related to fatiando/community#166
