### PR TITLE
Drop support for Python 3.8 and add Python 3.13

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install requirements
         run: python -m pip install -r env/requirements-style.txt

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REQUIREMENTS: env/requirements-docs.txt env/requirements-build.txt
-      PYTHON: "3.12"
+      PYTHON: "3.13"
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install requirements
         run: python -m pip install -r env/requirements-build.txt

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install requirements
         run: python -m pip install -r env/requirements-style.txt
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install requirements
         run: python -m pip install -r env/requirements-style.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,20 +40,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ["3.8", "3.12"]
+        python: ["3.9", "3.13"]
         include:
-          - python: "3.8"
+          - python: "3.9"
             dependencies: oldest
-          - python: "3.12"
+          - python: "3.13"
             dependencies: latest
-          # test on macos-13 (x86) using oldest dependencies and python 3.8
-          - os: macos-13
-            dependencies: oldest
-            python: "3.8"
-        exclude:
-          # don't test on macos-latest (arm64) with oldest dependencies
-          - os: macos-latest
-            python: "3.8"
 
     env:
       REQUIREMENTS: env/requirements-build.txt env/requirements-test.txt

--- a/doc/compatibility.rst
+++ b/doc/compatibility.rst
@@ -58,3 +58,5 @@ following releases to ensure compatibility:
       - **Last compatible release**
     * - 3.7
       - 0.1.0
+    * - 3.8
+      - 0.3.2

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -6,7 +6,7 @@ Installing
 Which Python?
 -------------
 
-You'll need **Python 3.8 or greater**.
+You'll need **Python 3.9 or greater**.
 See :ref:`python-versions` if you require support for older versions.
 
 We recommend using the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,18 +20,18 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
-    "numpy>=1.19",
-    "numba>=0.52",
+    "numpy>=1.23",
+    "numba>=0.58",
 ]
 
 [project.urls]


### PR DESCRIPTION
Bump numpy and numba as well to make them compatible.

Needed by #130 