### PR TITLE
Fix equations in docstring of point mass kernels

### DIFF
--- a/src/choclo/point/_forward.py
+++ b/src/choclo/point/_forward.py
@@ -32,7 +32,7 @@ def gravity_pot(easting_p, northing_p, upward_p, easting_q, northing_q, upward_q
     Gravitational potential field due to a point source.
 
     Returns the gravitational potential field produced by a single point source
-    on a single computation point
+    at a single computation point.
 
     Parameters
     ----------
@@ -80,7 +80,7 @@ def gravity_e(easting_p, northing_p, upward_p, easting_q, northing_q, upward_q, 
     Easting component of the gravitational acceleration due to a point source.
 
     Returns the easting component of the gravitational acceleration produced by
-    a single point source on a single computation point
+    a single point source at a single computation point.
 
     Parameters
     ----------
@@ -133,7 +133,7 @@ def gravity_n(easting_p, northing_p, upward_p, easting_q, northing_q, upward_q, 
     Northing component of the gravitational acceleration due to a point source.
 
     Returns the northing component of the gravitational acceleration produced
-    by a single point source on a single computation point
+    by a single point source at a single computation point.
 
     Parameters
     ----------
@@ -186,7 +186,7 @@ def gravity_u(easting_p, northing_p, upward_p, easting_q, northing_q, upward_q, 
     Upward component of the gravitational acceleration due to a point source.
 
     Returns the upward component of the gravitational acceleration produced by
-    a single point source on a single computation point
+    a single point source at a single computation point.
 
     Parameters
     ----------
@@ -239,7 +239,7 @@ def gravity_ee(easting_p, northing_p, upward_p, easting_q, northing_q, upward_q,
     Easting-easting component of the gravitational tensor due to a point source.
 
     Returns the easting-easting component of the gravitational tensor produced
-    by a single point source on a single computation point
+    by a single point source at a single computation point.
 
     Parameters
     ----------
@@ -299,7 +299,7 @@ def gravity_nn(easting_p, northing_p, upward_p, easting_q, northing_q, upward_q,
     Northing-northing component of the gravitational tensor due to point source.
 
     Returns the northing-northing component of the gravitational tensor
-    produced by a single point source on a single computation point
+    produced by a single point source at a single computation point.
 
     Parameters
     ----------
@@ -359,7 +359,7 @@ def gravity_uu(easting_p, northing_p, upward_p, easting_q, northing_q, upward_q,
     Upward-upward component of the gravitational tensor due to a point source.
 
     Returns the upward-upward component of the gravitational tensor
-    produced by a single point source on a single computation point
+    produced by a single point source at a single computation point.
 
     Parameters
     ----------
@@ -419,7 +419,7 @@ def gravity_en(easting_p, northing_p, upward_p, easting_q, northing_q, upward_q,
     Easting-northing component of the gravitational tensor due to point source.
 
     Returns the easting-northing component of the gravitational tensor
-    produced by a single point source on a single computation point
+    produced by a single point source at a single computation point.
 
     Parameters
     ----------
@@ -474,7 +474,7 @@ def gravity_eu(easting_p, northing_p, upward_p, easting_q, northing_q, upward_q,
     Easting-upward component of the gravitational tensor due to point source.
 
     Returns the easting-upward component of the gravitational tensor
-    produced by a single point source on a single computation point
+    produced by a single point source at a single computation point.
 
     Parameters
     ----------
@@ -529,7 +529,7 @@ def gravity_nu(easting_p, northing_p, upward_p, easting_q, northing_q, upward_q,
     Northing-upward component of the gravitational tensor due to point source.
 
     Returns the northing-upward component of the gravitational tensor
-    produced by a single point source on a single computation point
+    produced by a single point source at a single computation point.
 
     Parameters
     ----------

--- a/src/choclo/point/_kernels.py
+++ b/src/choclo/point/_kernels.py
@@ -428,7 +428,7 @@ def kernel_en(
     .. math::
 
         k_{xy}(\mathbf{p}, \mathbf{q}) =
-        \frac{\partial}{\partial x_p \partial y_p}
+        \frac{\partial^2}{\partial x_p \partial y_p}
         \left(
             \frac{1}{\lVert \mathbf{p} - \mathbf{q} \rVert_2}
         \right)
@@ -481,7 +481,7 @@ def kernel_eu(
     .. math::
 
         k_{xz}(\mathbf{p}, \mathbf{q}) =
-        \frac{\partial}{\partial x_p \partial z_p}
+        \frac{\partial^2}{\partial x_p \partial z_p}
         \left(
             \frac{1}{\lVert \mathbf{p} - \mathbf{q} \rVert_2}
         \right)
@@ -534,7 +534,7 @@ def kernel_nu(
     .. math::
 
         k_{yz}(\mathbf{p}, \mathbf{q}) =
-        \frac{\partial}{\partial y_p \partial z_p}
+        \frac{\partial^2}{\partial y_p \partial z_p}
         \left(
             \frac{1}{\lVert \mathbf{p} - \mathbf{q} \rVert_2}
         \right)

--- a/src/choclo/point/_kernels.py
+++ b/src/choclo/point/_kernels.py
@@ -95,7 +95,7 @@ def kernel_e(
     .. math::
 
         k_x(\mathbf{p}, \mathbf{q}) =
-        \frac{\partial}{\partial x}
+        \frac{\partial}{\partial x_p}
         \left(
             \frac{1}{\lVert \mathbf{p} - \mathbf{q} \rVert_2}
         \right)
@@ -103,7 +103,7 @@ def kernel_e(
         - \frac{
             x_p - x_q
         }{
-            \lVert \mathbf{p} - \mathbf{q} \rVert_2
+            \lVert \mathbf{p} - \mathbf{q} \rVert_2^3
         }
 
     where :math:`\lVert \cdot \rVert_2` refer to the :math:`L_2` norm (the
@@ -148,7 +148,7 @@ def kernel_n(
     .. math::
 
         k_y(\mathbf{p}, \mathbf{q}) =
-        \frac{\partial}{\partial y}
+        \frac{\partial}{\partial y_p}
         \left(
             \frac{1}{\lVert \mathbf{p} - \mathbf{q} \rVert_2}
         \right)
@@ -156,7 +156,7 @@ def kernel_n(
         - \frac{
             y_p - y_q
         }{
-            \lVert \mathbf{p} - \mathbf{q} \rVert_2
+            \lVert \mathbf{p} - \mathbf{q} \rVert_2^3
         }
 
     where :math:`\lVert \cdot \rVert_2` refer to the :math:`L_2` norm (the
@@ -201,7 +201,7 @@ def kernel_u(
     .. math::
 
         k_z(\mathbf{p}, \mathbf{q}) =
-        \frac{\partial}{\partial z}
+        \frac{\partial}{\partial z_p}
         \left(
             \frac{1}{\lVert \mathbf{p} - \mathbf{q} \rVert_2}
         \right)
@@ -209,7 +209,7 @@ def kernel_u(
         - \frac{
             z_p - z_q
         }{
-            \lVert \mathbf{p} - \mathbf{q} \rVert_2
+            \lVert \mathbf{p} - \mathbf{q} \rVert_2^3
         }
 
     where :math:`\lVert \cdot \rVert_2` refer to the :math:`L_2` norm (the
@@ -254,7 +254,7 @@ def kernel_ee(
     .. math::
 
         k_{xx}(\mathbf{p}, \mathbf{q}) =
-        \frac{\partial^2}{\partial x^2}
+        \frac{\partial^2}{\partial x_p^2}
         \left(
             \frac{1}{\lVert \mathbf{p} - \mathbf{q} \rVert_2}
         \right)
@@ -312,7 +312,7 @@ def kernel_nn(
     .. math::
 
         k_{yy}(\mathbf{p}, \mathbf{q}) =
-        \frac{\partial^2}{\partial y^2}
+        \frac{\partial^2}{\partial y_p^2}
         \left(
             \frac{1}{\lVert \mathbf{p} - \mathbf{q} \rVert_2}
         \right)
@@ -370,7 +370,7 @@ def kernel_uu(
     .. math::
 
         k_{zz}(\mathbf{p}, \mathbf{q}) =
-        \frac{\partial^2}{\partial z^2}
+        \frac{\partial^2}{\partial z_p^2}
         \left(
             \frac{1}{\lVert \mathbf{p} - \mathbf{q} \rVert_2}
         \right)
@@ -428,7 +428,7 @@ def kernel_en(
     .. math::
 
         k_{xy}(\mathbf{p}, \mathbf{q}) =
-        \frac{\partial}{\partial x \partial y}
+        \frac{\partial}{\partial x_p \partial y_p}
         \left(
             \frac{1}{\lVert \mathbf{p} - \mathbf{q} \rVert_2}
         \right)
@@ -481,7 +481,7 @@ def kernel_eu(
     .. math::
 
         k_{xz}(\mathbf{p}, \mathbf{q}) =
-        \frac{\partial}{\partial x \partial z}
+        \frac{\partial}{\partial x_p \partial z_p}
         \left(
             \frac{1}{\lVert \mathbf{p} - \mathbf{q} \rVert_2}
         \right)
@@ -534,7 +534,7 @@ def kernel_nu(
     .. math::
 
         k_{yz}(\mathbf{p}, \mathbf{q}) =
-        \frac{\partial}{\partial y \partial z}
+        \frac{\partial}{\partial y_p \partial z_p}
         \left(
             \frac{1}{\lVert \mathbf{p} - \mathbf{q} \rVert_2}
         \right)


### PR DESCRIPTION
The derivatives are with respect to the observation (xp, yp, zp) and not (x, y, z) which aren't defined. Add the missing cube to the first derivatives. Add missing square to partial cross derivatives.