### PR TITLE
Replace Codecov for custom HTML report in Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,7 +177,7 @@ jobs:
         run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: Setup caching for pip packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,8 @@ defaults:
     # Using "-l {0}" is necessary for conda environments to be activated
     # But this breaks on MacOS if using actions/setup-python:
     # https://github.com/actions/setup-python/issues/132
-    shell: bash
+    # -e makes sure jobs fail if any command fails
+    shell: bash -e -o pipefail -l {0}
 
 jobs:
   #############################################################################
@@ -129,22 +130,28 @@ jobs:
       - name: Run the tests
         run: make test
 
-      - name: Convert coverage report to XML for codecov
-        run: coverage xml
+      - name: Rename the coverage output
+        run: |
+          mv .coverage .coverage.${{ matrix.os }}_${{ matrix.python }}_${{ matrix.dependencies }}
 
       - name: Upload coverage as artifact
         uses: actions/upload-artifact@v7
         with:
-          name: coverage_${{ matrix.os }}_${{ matrix.dependencies }}
-          path: ./coverage.xml
+          path: .coverage.*
+          name: coverage_${{ matrix.os }}_${{ matrix.python }}_${{ matrix.dependencies }}
+          if-no-files-found: ignore
+          include-hidden-files: true
 
 
   #############################################################################
-  # Upload coverage report to codecov
-  codecov-upload:
-    runs-on: ubuntu-latest
-    environment: codecov
+  # Check coverage and upload a report
+  #
+  # Inspired by: https://hynek.me/articles/ditch-codecov-python/
+  coverage:
+    name: test coverage is 100%
+    if: always()
     needs: test
+    runs-on: ubuntu-latest
 
     steps:
 
@@ -160,25 +167,47 @@ jobs:
           # to be able to push to GitHub.
           persist-credentials: false
 
-      - name: Download coverage report artifacts
-        # Download coverage reports from every runner.
-        # Maximum coverage is achieved by combining reports from every runner.
-        # Each coverage file will live in its own folder with the same name as
-        # the artifact.
+      - uses: actions/setup-python@v6
+        with:
+          # Use latest Python, so it understands all syntax.
+          python-version: "3.14"
+
+      - name: Get the pip cache folder
+        id: pip-cache
+        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+
+      - name: Setup caching for pip packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-coverage
+
+      - name: Download coverage artifacts
         uses: actions/download-artifact@v8
         with:
           pattern: coverage_*
+          # If true, the downloaded artifacts will be in the same directory
+          # specified by path.
+          merge-multiple: true
 
-      - name: List all downloaded artifacts
-        run: ls -l -R .
+      - name: Install coverage.py
+        run: python -m pip install --upgrade coverage[toml]
 
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad
+      - name: Combine coverage
+        run: python -m coverage combine
+
+      - name: Make an HTML report
+        run: python -m coverage html --skip-empty
+
+      - name: Report coverage on the job summary
+        run: python -m coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
+
+      - name: Fail if coverage is not 100%
+        run: python -m coverage report --fail-under=100
+
+      - name: Upload HTML report if check failed
+        uses: actions/upload-artifact@v4
         with:
-          # Upload all coverage report files
-          files: ./coverage_*/coverage.xml
-          # Fail the job so we know coverage isn't being updated. Otherwise it
-          # can silently drop and we won't know.
-          fail_ci_if_error: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          name: html-report
+          path: htmlcov
+        if: ${{ failure() }}

--- a/src/choclo/utils.py
+++ b/src/choclo/utils.py
@@ -206,3 +206,9 @@ def distance_spherical_core(
         (radius_p - radius_q) ** 2 + 2 * radius_p * radius_q * (1 - cospsi)
     )
     return distance, cospsi, coslambda
+
+
+def untested_function(x):
+    if x == 0:
+        return None
+    return x**2

--- a/src/choclo/utils.py
+++ b/src/choclo/utils.py
@@ -206,9 +206,3 @@ def distance_spherical_core(
         (radius_p - radius_q) ** 2 + 2 * radius_p * radius_q * (1 - cospsi)
     )
     return distance, cospsi, coslambda
-
-
-def untested_function(x):
-    if x == 0:
-        return None
-    return x**2


### PR DESCRIPTION
Codecov is great but it's a third-party service that requires another login and often breaks. Replace it with a job in Actions that checks coverage and report the coverage results in the CI log. The job fails if coverage is below 100%. Extend options passed to bash in test workflow.

**Relevant issues/PRs:**

Inspired by https://github.com/fatiando/boule/pull/251.
Follow up of #146.
