### PR TITLE
General improvements to install and version compatibility pages

### DIFF
--- a/doc/compatibility.rst
+++ b/doc/compatibility.rst
@@ -16,6 +16,8 @@ Choclo uses `semantic versioning <https://semver.org/>`__ (i.e.,
 * Bug fix releases fix errors in a previous release without adding new
   functionality. Users can upgrade minor versions without changing their code.
 
+**We aim for Choclo to be backwards compatible whenever possible and will make
+major releases sparingly and with ample warning.**
 We will add ``FutureWarning`` messages about deprecations ahead of making any
 breaking changes to give users a chance to upgrade.
 
@@ -23,8 +25,9 @@ breaking changes to give users a chance to upgrade.
 
     The above does not apply to versions < ``1.0.0``. All ``0.*`` versions may
     deprecate, remove, or change functionality between releases. Proper
-    warnings will be raised and any breaking changes will be marked as such in
+    warnings may be raised, and any breaking changes will be marked as such in
     the :ref:`changes`.
+
 
 .. _dependency-versions:
 
@@ -42,12 +45,18 @@ older ones are still working without causing problems.
 Whenever support for a version is dropped, we will include a note in the
 :ref:`changes`.
 
+.. seealso::
+
+    Exact version constraints on our dependencies can be found in the
+    `pyproject.toml file <https://github.com/fatiando/choclo/blob/main/pyproject.toml>`__.
+
 
 .. _python-versions:
 
 Supported Python versions
 -------------------------
 
+Choclo supports Python versions greater than the ones listed below.
 If you require support for older Python versions, please pin Choclo to the
 following releases to ensure compatibility:
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -3,19 +3,59 @@
 Installing
 ==========
 
-Which Python?
--------------
+There are different ways to install Choclo:
 
-You'll need **Python 3.9 or greater**.
-See :ref:`python-versions` if you require support for older versions.
+.. tab-set::
 
-We recommend using the
-`Anaconda Python distribution <https://www.anaconda.com/download>`__
-to ensure you have all dependencies installed and the ``conda`` package manager
-available.
-Installing Anaconda does not require administrative rights to your computer and
-doesn't interfere with any other Python installations in your system.
+    .. tab-item:: conda/mamba
 
+        Using the `conda <https://conda.io/>`__ package manager (or ``mamba``)
+        that comes with the Anaconda, Miniconda, or Miniforge distributions:
+
+        .. code:: bash
+
+            conda install choclo --channel conda-forge
+
+    .. tab-item:: pip
+
+        Using the `pip <https://pypi.org/project/pip/>`__ package manager:
+
+        .. code:: bash
+
+            python -m pip install choclo
+
+    .. tab-item:: Development version
+
+        You can use ``pip`` to install the latest **unreleased** version from
+        GitHub (**not recommended** in most situations):
+
+        .. code:: bash
+
+            python -m pip install --upgrade git+https://github.com/fatiando/choclo
+
+.. tip::
+
+    The commands above should be executed in a terminal. On Windows, use the
+    ``cmd.exe`` or the "Anaconda Prompt" / "Miniforge Prompt" app if you're using
+    Anaconda / Miniforge.
+
+.. admonition:: Which Python?
+    :class: tip
+
+    See :ref:`python-versions` for a list of supported Python versions.
+
+.. note::
+
+   We recommend using the
+   `Miniforge distribution <https://conda-forge.org/download/>`__
+   to ensure that you have the ``conda`` package manager available.
+   Installing Miniforge does not require administrative rights to your computer
+   and doesn't interfere with any other Python installations in your system.
+   It's also much smaller than the Anaconda distribution and is less likely to
+   break when installing new software.
+
+
+.. _dependencies:
 
 Dependencies
 ------------
@@ -24,48 +64,16 @@ The required dependencies should be installed automatically when you install
 Choclo using ``conda`` or ``pip``. Optional dependencies have to be
 installed manually.
 
-.. note::
-
-    See :ref:`dependency-versions` for the our policy of oldest supported
-    versions of each dependency.
-
 Required:
 
 * `numpy <http://www.numpy.org/>`__
 * `numba <https://numba.pydata.org/>`__
 
+.. note::
+
+    See :ref:`dependency-versions` for our policy of oldest supported
+    versions of each dependency.
+
 The examples in the :ref:`overview` also use:
 
 * `matplotlib <https://matplotlib.org/>`__ for plotting
-
-Installing with conda
----------------------
-
-You can install Choclo using the `conda package manager
-<https://conda.io/>`__ that comes with the Anaconda distribution::
-
-    conda install choclo --channel conda-forge
-
-
-Installing with pip
--------------------
-
-Alternatively, you can also use the `pip package manager
-<https://pypi.org/project/pip/>`__::
-
-    pip install choclo
-
-
-Installing the latest development version
------------------------------------------
-
-You can use ``pip`` to install the latest source from Github::
-
-    pip install https://github.com/fatiando/choclo/archive/main.zip
-
-Alternatively, you can clone the git repository locally and install from
-there::
-
-    git clone https://github.com/fatiando/choclo.git
-    cd choclo
-    pip install .


### PR DESCRIPTION
Add more links to other sections, including the version compatibility. Add statement about the minimum Python version required. Prioritize the miniforge install and recommendation. Add the dependency version policy and link to pyproject.toml.